### PR TITLE
Commandline argument -configFile:{filename} can be used to override d…

### DIFF
--- a/src/main/java/kernbeisser/Config/Config.java
+++ b/src/main/java/kernbeisser/Config/Config.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.stream.Collectors;
+import kernbeisser.Main;
 import kernbeisser.Useful.Tools;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 @Data
 public final class Config {
 
-  private static final Path CONFIG_PATH = Paths.get("config.json");
+  private static Path CONFIG_PATH = Paths.get("config.json");
 
   @Getter(AccessLevel.NONE)
   private static final Gson gson = new GsonBuilder().serializeNulls().setPrettyPrinting().create();
@@ -38,6 +39,18 @@ public final class Config {
   private static final Config config = loadJSON();
 
   public static void safeFile() {
+    safeInFile(getConfig());
+  }
+
+  public static void safeFile(String[] args) {
+    for (String arg : args) {
+      if (arg.startsWith("-configFile:")) {
+        String configFile = arg.split(":")[1];
+        CONFIG_PATH = Paths.get(configFile);
+        Main.logger.info("Using custom configuration from " + configFile);
+        break;
+      }
+    }
     safeInFile(getConfig());
   }
 

--- a/src/main/java/kernbeisser/Main.java
+++ b/src/main/java/kernbeisser/Main.java
@@ -45,7 +45,7 @@ public class Main {
 
   public static void main(String[] args) throws UnsupportedLookAndFeelException {
     Thread.setDefaultUncaughtExceptionHandler(Main::logUncaughtException);
-    Config.safeFile();
+    Config.safeFile(args);
     Locale.setDefault(Locale.GERMAN);
     logger.info("Free memory at start " + Runtime.getRuntime().freeMemory() / 1048576 + "MB");
     // Runs the jar with more memory if not enough is reserved


### PR DESCRIPTION
…efault configuration in config .json with {filename}, so different launchers can launch different database connections