### PR TITLE
660 remove translation of report implementation to deployed report definition

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,8 +9,8 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.16/6dc192c7f93ec1853f70d59d8a6dcf94eb42866/lombok-1.18.16.jar" />
         </processorPath>
-        <module name="Kernbeisser.kernbeisser.test" />
-        <module name="Kernbeisser.kernbeisser.main" />
+        <module name="kernbeisser.main" />
+        <module name="kernbeisser.test" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="1.8" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -43,6 +43,45 @@
       <option name="IGNORE_POINT_TO_ITSELF" value="false" />
       <option name="myAdditionalJavadocTags" value="link(),See" />
     </inspection_tool>
+    <inspection_tool class="JavadocDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ADDITIONAL_TAGS" value="link(),See" />
+    </inspection_tool>
+    <inspection_tool class="MagicConstant" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WEAK WARNING" enabled="true" editorAttributes="INFO_ATTRIBUTES" />
+    </inspection_tool>
+    <inspection_tool class="MissingJavadoc" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="PACKAGE_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="MODULE_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="TOP_LEVEL_CLASS_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="INNER_CLASS_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="METHOD_SETTINGS">
+        <Options>
+          <option name="REQUIRED_TAGS" value="@return@param@throws or @exception" />
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+      <option name="FIELD_SETTINGS">
+        <Options>
+          <option name="ENABLED" value="false" />
+        </Options>
+      </option>
+    </inspection_tool>
     <inspection_tool class="SuspiciousMethodCalls" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="REPORT_CONVERTIBLE_METHOD_CALLS" value="true" />
     </inspection_tool>

--- a/.idea/jpa-buddy.xml
+++ b/.idea/jpa-buddy.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="JpaBuddyIdeaProjectConfig">
     <option name="defaultUnitInitialized" value="true" />
+    <option name="renamerInitialized" value="true" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -30,4 +30,7 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
 </project>

--- a/.idea/runConfigurations/Main_Proxy_.xml
+++ b/.idea/runConfigurations/Main_Proxy_.xml
@@ -3,7 +3,7 @@
     <option name="ALTERNATIVE_JRE_PATH" value="1.8" />
     <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="kernbeisser.Main" />
-    <module name="Kernbeisser.kernbeisser.main" />
+    <module name="kernbeisser.main" />
     <option name="VM_PARAMETERS" value="-splash:KernbeisserSplash.png -javaagent:&quot;src/main/resources/Agent/Agent-1.0-SNAPSHOT.jar&quot;=&quot;kernbeisser$kernbeisser.Security.Key$kernbeisser.Security.Access.Access.hasAccess(this,\&quot;%s\&quot;, \&quot;%s\&quot;, %dL);&quot;" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/production/config.json
+++ b/production/config.json
@@ -20,26 +20,6 @@
     },
     "outputDirectory": {
       "path": "output"
-    },
-    "reports": {
-      "userBalanceFileName": "GuthabenUebersicht.jrxml",
-      "inventoryStock": "Inventur_Bestaende.jrxml",
-      "preOrderChecklist": "Abhakplan.jrxml",
-      "trialMemberReportFileName": "Probemitglieder.jrxml",
-      "accountingTransactionReportFileName": "BuchhaltungGuthabenAenderungen.jrxml",
-      "inventoryShelfOverview": "Inventur_Regaluebersicht.jrxml",
-      "inventoryCountingLists": "Inventur_Zaehlliste.jrxml",
-      "priceList": "Preisliste.jrxml",
-      "articleLabel": "Etiketten.jrxml",
-      "transactionStatement": "Kontoauszug.jrxml",
-      "inventoryShelfStocks": "Inventur_Regal_Bestaende.jrxml",
-      "tillrollFileName": "Bonrolle.jrxml",
-      "loginInfo": "LoginInformation.jrxml",
-      "inventoryShelfDetails": "Inventur_Regaldetails.jrxml",
-      "permissionHolders": "RollenInhaber.jrxml",
-      "accountingReportFileName": "BuchhaltungBonUebersicht.jrxml",
-      "keyUserListFileName": "BenutzerSchluessel.jrxml",
-      "invoiceFileName": "Kerni_Rechnung.jrxml"
     }
   },
   "preorders": {

--- a/src/main/java/kernbeisser/Reports/AccountingReport.java
+++ b/src/main/java/kernbeisser/Reports/AccountingReport.java
@@ -1,5 +1,14 @@
 package kernbeisser.Reports;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import javax.persistence.NoResultException;
+import javax.swing.*;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.*;
 import kernbeisser.Enums.VAT;
@@ -9,16 +18,6 @@ import kernbeisser.Useful.Date;
 import lombok.Cleanup;
 import org.jetbrains.annotations.NotNull;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import javax.persistence.NoResultException;
-import javax.swing.*;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 public class AccountingReport extends Report {
   private final long reportNo;
   private final List<Transaction> transactions;
@@ -26,7 +25,7 @@ public class AccountingReport extends Report {
   private final boolean withNames;
 
   public AccountingReport(long reportNo, List<Transaction> transactions, boolean withNames)
-          throws NoTransactionsFoundException {
+      throws NoTransactionsFoundException {
     super(ReportFileNames.ACCOUNTING_REPORT_FILENAME);
     this.reportNo = reportNo;
     this.transactions = transactions;
@@ -45,11 +44,11 @@ public class AccountingReport extends Report {
     EntityTransaction et = em.getTransaction();
     et.begin();
     List<Purchase> purchases =
-            em.createQuery(
-                            "select p from Purchase p where p.session in (select s from SaleSession s where s.transaction in (:transactions))",
-                            Purchase.class)
-                    .setParameter("transactions", transactions)
-                    .getResultList();
+        em.createQuery(
+                "select p from Purchase p where p.session in (select s from SaleSession s where s.transaction in (:transactions))",
+                Purchase.class)
+            .setParameter("transactions", transactions)
+            .getResultList();
     if (purchases.isEmpty()) {
       throw new NoTransactionsFoundException();
     }
@@ -190,7 +189,7 @@ public class AccountingReport extends Report {
     }
     long lastTransactionId = transactions.stream().mapToLong(Transaction::getId).max().getAsLong();
     Map<String, Object> reportParams =
-            UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
+        UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
     reportParams.put("transactionSaldo", transactionSaldo);
     reportParams.put("transactionCreditPayIn", transactionCreditPayIn);
     reportParams.put("transactionSpecialPayments", transactionSpecialPayments);

--- a/src/main/java/kernbeisser/Reports/AccountingReport.java
+++ b/src/main/java/kernbeisser/Reports/AccountingReport.java
@@ -1,11 +1,5 @@
 package kernbeisser.Reports;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import javax.persistence.NoResultException;
-import javax.swing.*;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.*;
 import kernbeisser.Enums.VAT;
@@ -15,22 +9,34 @@ import kernbeisser.Useful.Date;
 import lombok.Cleanup;
 import org.jetbrains.annotations.NotNull;
 
-public class AccountingReport extends Report {
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import javax.persistence.NoResultException;
+import javax.swing.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+public class AccountingReport extends Report {
   private final long reportNo;
   private final List<Transaction> transactions;
   private final List<Purchase> purchases;
   private final boolean withNames;
 
   public AccountingReport(long reportNo, List<Transaction> transactions, boolean withNames)
-      throws NoTransactionsFoundException {
-    super(
-        "accountingReportFileName",
-        String.format("KernbeisserBuchhaltungBonUebersicht_%d", reportNo));
+          throws NoTransactionsFoundException {
+    super(ReportFileNames.ACCOUNTING_REPORT_FILENAME);
     this.reportNo = reportNo;
     this.transactions = transactions;
     this.purchases = getPurchases();
     this.withNames = withNames;
+  }
+
+  @Override
+  String createOutFileName() {
+    return String.format("KernbeisserBuchhaltungBonUebersicht_%d", reportNo);
   }
 
   private List<Purchase> getPurchases() throws NoResultException {
@@ -39,11 +45,11 @@ public class AccountingReport extends Report {
     EntityTransaction et = em.getTransaction();
     et.begin();
     List<Purchase> purchases =
-        em.createQuery(
-                "select p from Purchase p where p.session in (select s from SaleSession s where s.transaction in (:transactions))",
-                Purchase.class)
-            .setParameter("transactions", transactions)
-            .getResultList();
+            em.createQuery(
+                            "select p from Purchase p where p.session in (select s from SaleSession s where s.transaction in (:transactions))",
+                            Purchase.class)
+                    .setParameter("transactions", transactions)
+                    .getResultList();
     if (purchases.isEmpty()) {
       throw new NoTransactionsFoundException();
     }
@@ -184,7 +190,7 @@ public class AccountingReport extends Report {
     }
     long lastTransactionId = transactions.stream().mapToLong(Transaction::getId).max().getAsLong();
     Map<String, Object> reportParams =
-        UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
+            UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
     reportParams.put("transactionSaldo", transactionSaldo);
     reportParams.put("transactionCreditPayIn", transactionCreditPayIn);
     reportParams.put("transactionSpecialPayments", transactionSpecialPayments);

--- a/src/main/java/kernbeisser/Reports/AccountingTransactionsReport.java
+++ b/src/main/java/kernbeisser/Reports/AccountingTransactionsReport.java
@@ -1,14 +1,13 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Transaction;
-import kernbeisser.DBEntities.User;
-import kernbeisser.DBEntities.UserGroup;
-import kernbeisser.Exeptions.NoTransactionsFoundException;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.DBEntities.UserGroup;
+import kernbeisser.Exeptions.NoTransactionsFoundException;
 
 public class AccountingTransactionsReport extends Report {
   private final long reportNo;
@@ -17,11 +16,11 @@ public class AccountingTransactionsReport extends Report {
   private final boolean printValueSums;
 
   public AccountingTransactionsReport(
-          long reportNo,
-          List<Transaction> transactions,
-          UserNameObfuscation withNames,
-          boolean printValueSums)
-          throws NoTransactionsFoundException {
+      long reportNo,
+      List<Transaction> transactions,
+      UserNameObfuscation withNames,
+      boolean printValueSums)
+      throws NoTransactionsFoundException {
     super(ReportFileNames.ACCOUNTING_TRANSACTION_REPORT_FILENAME);
     this.reportNo = reportNo;
     this.transactions = transactions;
@@ -38,7 +37,7 @@ public class AccountingTransactionsReport extends Report {
   Map<String, Object> getReportParams() {
     long lastTransactionId = transactions.stream().mapToLong(Transaction::getId).max().getAsLong();
     Map<String, Object> reportParams =
-            UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
+        UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
     reportParams.put("userGroup", User.getKernbeisserUser().getUserGroup());
     reportParams.put("reportNo", reportNo);
     reportParams.put("reportTitle", AccountingReport.getReportTitle(reportNo, transactions));

--- a/src/main/java/kernbeisser/Reports/AccountingTransactionsReport.java
+++ b/src/main/java/kernbeisser/Reports/AccountingTransactionsReport.java
@@ -1,28 +1,28 @@
 package kernbeisser.Reports;
 
-import java.util.*;
-import java.util.stream.Collectors;
 import kernbeisser.DBEntities.Transaction;
 import kernbeisser.DBEntities.User;
 import kernbeisser.DBEntities.UserGroup;
 import kernbeisser.Exeptions.NoTransactionsFoundException;
 
-public class AccountingTransactionsReport extends Report {
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+public class AccountingTransactionsReport extends Report {
   private final long reportNo;
   private final List<Transaction> transactions;
   private final UserNameObfuscation withNames;
   private final boolean printValueSums;
 
   public AccountingTransactionsReport(
-      long reportNo,
-      List<Transaction> transactions,
-      UserNameObfuscation withNames,
-      boolean printValueSums)
-      throws NoTransactionsFoundException {
-    super(
-        "accountingTransactionReportFileName",
-        String.format("KernbeisserBuchhaltungEinSonderzahlungen_%d", reportNo));
+          long reportNo,
+          List<Transaction> transactions,
+          UserNameObfuscation withNames,
+          boolean printValueSums)
+          throws NoTransactionsFoundException {
+    super(ReportFileNames.ACCOUNTING_TRANSACTION_REPORT_FILENAME);
     this.reportNo = reportNo;
     this.transactions = transactions;
     this.withNames = withNames;
@@ -30,10 +30,15 @@ public class AccountingTransactionsReport extends Report {
   }
 
   @Override
+  String createOutFileName() {
+    return String.format("KernbeisserBuchhaltungEinSonderzahlungen_%d", reportNo);
+  }
+
+  @Override
   Map<String, Object> getReportParams() {
     long lastTransactionId = transactions.stream().mapToLong(Transaction::getId).max().getAsLong();
     Map<String, Object> reportParams =
-        UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
+            UserGroup.getValueAggregatesAtTransactionId(lastTransactionId);
     reportParams.put("userGroup", User.getKernbeisserUser().getUserGroup());
     reportParams.put("reportNo", reportNo);
     reportParams.put("reportTitle", AccountingReport.getReportTitle(reportNo, transactions));

--- a/src/main/java/kernbeisser/Reports/ArticleLabel.java
+++ b/src/main/java/kernbeisser/Reports/ArticleLabel.java
@@ -1,24 +1,29 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Article;
+import kernbeisser.DBEntities.Articles;
+import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
+import kernbeisser.Useful.Date;
+
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import kernbeisser.DBEntities.Article;
-import kernbeisser.DBEntities.Articles;
-import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
-import kernbeisser.Useful.Date;
 
 public class ArticleLabel extends Report {
-
   private final List<Article> articles;
 
   public ArticleLabel(List<Article> articles) {
-    super("articleLabel", "Etiketten_" + Date.INSTANT_DATE_TIME.format(Instant.now()));
+    super(ReportFileNames.ARTICLE_LABEL_REPORT_FILENAME);
     setDuplexPrint(false);
     this.articles = articles;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Etiketten_" + Date.INSTANT_DATE_TIME.format(Instant.now());
   }
 
   @Override
@@ -30,8 +35,8 @@ public class ArticleLabel extends Report {
   Collection<?> getDetailCollection() {
     Map<Integer, Instant> lastDeliveries = Articles.getLastDeliveries();
     return articles.stream()
-        .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
-        .sorted(
+            .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
+            .sorted(
             Comparator.comparing(PriceListReportArticle::getSuppliersShortName)
                 .thenComparingInt(PriceListReportArticle::getSuppliersItemNumber))
         .collect(Collectors.toList());

--- a/src/main/java/kernbeisser/Reports/ArticleLabel.java
+++ b/src/main/java/kernbeisser/Reports/ArticleLabel.java
@@ -1,16 +1,15 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Article;
-import kernbeisser.DBEntities.Articles;
-import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
-import kernbeisser.Useful.Date;
-
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Article;
+import kernbeisser.DBEntities.Articles;
+import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
+import kernbeisser.Useful.Date;
 
 public class ArticleLabel extends Report {
   private final List<Article> articles;
@@ -35,8 +34,8 @@ public class ArticleLabel extends Report {
   Collection<?> getDetailCollection() {
     Map<Integer, Instant> lastDeliveries = Articles.getLastDeliveries();
     return articles.stream()
-            .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
-            .sorted(
+        .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
+        .sorted(
             Comparator.comparing(PriceListReportArticle::getSuppliersShortName)
                 .thenComparingInt(PriceListReportArticle::getSuppliersItemNumber))
         .collect(Collectors.toList());

--- a/src/main/java/kernbeisser/Reports/InventoryCountingLists.java
+++ b/src/main/java/kernbeisser/Reports/InventoryCountingLists.java
@@ -1,13 +1,12 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryArticle;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryArticle;
 
 public class InventoryCountingLists extends Report {
   private final Collection<Shelf> shelves;
@@ -35,7 +34,7 @@ public class InventoryCountingLists extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return shelves.stream()
-            .flatMap(InventoryArticle::articleStreamOfShelf)
+        .flatMap(InventoryArticle::articleStreamOfShelf)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/InventoryCountingLists.java
+++ b/src/main/java/kernbeisser/Reports/InventoryCountingLists.java
@@ -1,23 +1,28 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryArticle;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryArticle;
 
 public class InventoryCountingLists extends Report {
-
   private final Collection<Shelf> shelves;
   private final LocalDate inventoryDate;
 
   public InventoryCountingLists(Collection<Shelf> shelves, LocalDate inventoryDate) {
-    super("inventoryCountingLists", "Zähllisten_" + inventoryDate.toString());
+    super(ReportFileNames.INVENTORY_COUNTING_LISTS_REPORT_FILENAME);
     this.inventoryDate = inventoryDate;
     setDuplexPrint(false);
     this.shelves = shelves;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Zähllisten_" + inventoryDate.toString();
   }
 
   @Override
@@ -30,7 +35,7 @@ public class InventoryCountingLists extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return shelves.stream()
-        .flatMap(InventoryArticle::articleStreamOfShelf)
+            .flatMap(InventoryArticle::articleStreamOfShelf)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/InventoryShelfDetails.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfDetails.java
@@ -1,22 +1,27 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryShelfDetail;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryShelfDetail;
 
 public class InventoryShelfDetails extends Report {
-
   private final Collection<Shelf> shelves;
   private final LocalDate inventoryDate;
 
   public InventoryShelfDetails(Collection<Shelf> shelves, LocalDate inventoryDate) {
-    super("inventoryShelfDetails", "Regaldetails_" + inventoryDate.toString());
+    super(ReportFileNames.INVENTORY_SHELF_DETAILS_REPORT_FILENAME);
     this.inventoryDate = inventoryDate;
     this.shelves = shelves;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Regaldetails_" + inventoryDate.toString();
   }
 
   @Override
@@ -29,7 +34,7 @@ public class InventoryShelfDetails extends Report {
   @Override
   Collection<InventoryShelfDetail> getDetailCollection() {
     return shelves.stream()
-        .flatMap(InventoryShelfDetail::detailsOfShelf)
+            .flatMap(InventoryShelfDetail::detailsOfShelf)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/InventoryShelfDetails.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfDetails.java
@@ -1,13 +1,12 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryShelfDetail;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryShelfDetail;
 
 public class InventoryShelfDetails extends Report {
   private final Collection<Shelf> shelves;
@@ -34,7 +33,7 @@ public class InventoryShelfDetails extends Report {
   @Override
   Collection<InventoryShelfDetail> getDetailCollection() {
     return shelves.stream()
-            .flatMap(InventoryShelfDetail::detailsOfShelf)
+        .flatMap(InventoryShelfDetail::detailsOfShelf)
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/InventoryShelfOverview.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfOverview.java
@@ -1,11 +1,10 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Shelf;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import kernbeisser.DBEntities.Shelf;
 
 public class InventoryShelfOverview extends Report {
 

--- a/src/main/java/kernbeisser/Reports/InventoryShelfOverview.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfOverview.java
@@ -1,10 +1,11 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Shelf;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import kernbeisser.DBEntities.Shelf;
 
 public class InventoryShelfOverview extends Report {
 
@@ -12,9 +13,14 @@ public class InventoryShelfOverview extends Report {
   private final LocalDate inventoryDate;
 
   public InventoryShelfOverview(Collection<Shelf> shelves, LocalDate inventoryDate) {
-    super("inventoryShelfOverview", "Regalübersicht_" + inventoryDate.toString());
+    super(ReportFileNames.INVENTORY_SHELF_OVERVIEW_REPORT_FILENAME);
     this.inventoryDate = inventoryDate;
     this.shelves = shelves;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Regalübersicht_" + inventoryDate.toString();
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/InventoryShelfStocks.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfStocks.java
@@ -1,13 +1,12 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryArticleStock;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryArticleStock;
 
 public class InventoryShelfStocks extends Report {
 
@@ -36,7 +35,7 @@ public class InventoryShelfStocks extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return shelves.stream()
-            .flatMap(InventoryArticleStock::stockStreamOfShelf)
+        .flatMap(InventoryArticleStock::stockStreamOfShelf)
         .filter(s -> s.getCount() != 0.0)
         .collect(Collectors.toList());
   }

--- a/src/main/java/kernbeisser/Reports/InventoryShelfStocks.java
+++ b/src/main/java/kernbeisser/Reports/InventoryShelfStocks.java
@@ -1,12 +1,13 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Shelf;
+import kernbeisser.Reports.ReportDTO.InventoryArticleStock;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import kernbeisser.DBEntities.Shelf;
-import kernbeisser.Reports.ReportDTO.InventoryArticleStock;
 
 public class InventoryShelfStocks extends Report {
 
@@ -14,10 +15,15 @@ public class InventoryShelfStocks extends Report {
   private final LocalDate inventoryDate;
 
   public InventoryShelfStocks(Collection<Shelf> shelves, LocalDate inventoryDate) {
-    super("inventoryShelfStocks", "InventurRegalBestände_" + inventoryDate.toString());
+    super(ReportFileNames.INVENTORY_SHELF_STOCKS);
     this.inventoryDate = inventoryDate;
     setDuplexPrint(false);
     this.shelves = shelves;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "InventurRegalBestände_" + inventoryDate.toString();
   }
 
   @Override
@@ -30,7 +36,7 @@ public class InventoryShelfStocks extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return shelves.stream()
-        .flatMap(InventoryArticleStock::stockStreamOfShelf)
+            .flatMap(InventoryArticleStock::stockStreamOfShelf)
         .filter(s -> s.getCount() != 0.0)
         .collect(Collectors.toList());
   }

--- a/src/main/java/kernbeisser/Reports/InventoryStocks.java
+++ b/src/main/java/kernbeisser/Reports/InventoryStocks.java
@@ -1,12 +1,11 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.ArticleStock;
-import kernbeisser.DBEntities.Shelf;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import kernbeisser.DBEntities.ArticleStock;
+import kernbeisser.DBEntities.Shelf;
 
 public class InventoryStocks extends Report {
 

--- a/src/main/java/kernbeisser/Reports/InventoryStocks.java
+++ b/src/main/java/kernbeisser/Reports/InventoryStocks.java
@@ -1,20 +1,26 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.ArticleStock;
+import kernbeisser.DBEntities.Shelf;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import kernbeisser.DBEntities.ArticleStock;
-import kernbeisser.DBEntities.Shelf;
 
 public class InventoryStocks extends Report {
 
   private final LocalDate inventoryDate;
 
   public InventoryStocks(LocalDate inventoryDate) {
-    super("inventoryStock", "InventurBestände_" + inventoryDate.toString());
+    super(ReportFileNames.INVENTORY_STOCKS);
     this.inventoryDate = inventoryDate;
     setDuplexPrint(false);
+  }
+
+  @Override
+  String createOutFileName() {
+    return "InventurBestände_" + inventoryDate.toString();
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/InvoiceReport.java
+++ b/src/main/java/kernbeisser/Reports/InvoiceReport.java
@@ -1,30 +1,32 @@
 package kernbeisser.Reports;
 
-import java.time.Instant;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import kernbeisser.DBEntities.Purchase;
 import kernbeisser.DBEntities.ShoppingItem;
 import kernbeisser.Enums.Setting;
 import kernbeisser.Enums.ShoppingItemSum;
 import kernbeisser.Enums.VAT;
 
-public class InvoiceReport extends Report {
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+public class InvoiceReport extends Report {
   private final Purchase purchase;
   private Instant at;
 
   public InvoiceReport(Purchase purchase) {
-    super(
-        "invoiceFileName",
-        String.format(
-            "%d_%s_%s_%s",
+    super(ReportFileNames.INVOICE_REPORT_FILENAME);
+    this.purchase = purchase;
+  }
+
+  @Override
+  String createOutFileName() {
+    return String.format("%d_%s_%s_%s",
             purchase.getId(),
             purchase.getSession().getCustomer().getFirstName(),
             purchase.getSession().getCustomer().getSurname(),
-            purchase.getCreateDate().toString()));
-    this.purchase = purchase;
+            purchase.getCreateDate().toString());
   }
 
   public InvoiceReport atPurchaseTime() {

--- a/src/main/java/kernbeisser/Reports/InvoiceReport.java
+++ b/src/main/java/kernbeisser/Reports/InvoiceReport.java
@@ -1,15 +1,14 @@
 package kernbeisser.Reports;
 
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import kernbeisser.DBEntities.Purchase;
 import kernbeisser.DBEntities.ShoppingItem;
 import kernbeisser.Enums.Setting;
 import kernbeisser.Enums.ShoppingItemSum;
 import kernbeisser.Enums.VAT;
-
-import java.time.Instant;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 public class InvoiceReport extends Report {
   private final Purchase purchase;
@@ -22,11 +21,12 @@ public class InvoiceReport extends Report {
 
   @Override
   String createOutFileName() {
-    return String.format("%d_%s_%s_%s",
-            purchase.getId(),
-            purchase.getSession().getCustomer().getFirstName(),
-            purchase.getSession().getCustomer().getSurname(),
-            purchase.getCreateDate().toString());
+    return String.format(
+        "%d_%s_%s_%s",
+        purchase.getId(),
+        purchase.getSession().getCustomer().getFirstName(),
+        purchase.getSession().getCustomer().getSurname(),
+        purchase.getCreateDate().toString());
   }
 
   public InvoiceReport atPurchaseTime() {

--- a/src/main/java/kernbeisser/Reports/KeyUserList.java
+++ b/src/main/java/kernbeisser/Reports/KeyUserList.java
@@ -1,11 +1,5 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.User;
-import lombok.Cleanup;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -14,6 +8,11 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.User;
+import lombok.Cleanup;
 
 public class KeyUserList extends Report {
 
@@ -27,8 +26,7 @@ public class KeyUserList extends Report {
   @Override
   String createOutFileName() {
     return String.format(
-            "Ladenbenutzerschlüssel_%s",
-            Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)));
+        "Ladenbenutzerschlüssel_%s", Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)));
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/KeyUserList.java
+++ b/src/main/java/kernbeisser/Reports/KeyUserList.java
@@ -1,5 +1,11 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.User;
+import lombok.Cleanup;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -8,23 +14,21 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.User;
-import lombok.Cleanup;
 
 public class KeyUserList extends Report {
+
   private final String sortOrder;
 
   public KeyUserList(String sortOrder) {
-    super(
-        "keyUserListFileName",
-        String.format(
-            "Ladenbenutzerschlüssel_%s",
-            Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES))));
-
+    super(ReportFileNames.KEY_USER_LIST_REPORT_FILENAME);
     this.sortOrder = sortOrder;
+  }
+
+  @Override
+  String createOutFileName() {
+    return String.format(
+            "Ladenbenutzerschlüssel_%s",
+            Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)));
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/LoginInfo.java
+++ b/src/main/java/kernbeisser/Reports/LoginInfo.java
@@ -1,20 +1,25 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.User;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import kernbeisser.DBEntities.User;
 
 public class LoginInfo extends Report {
-
   private final User user;
   private final String newPassword;
 
   public LoginInfo(User user, String newPassword) {
-    super("loginInfo", "loginInfo_" + user.getUsername());
+    super(ReportFileNames.LOGININFO_REPORT_FILENAME);
     this.user = user;
     this.newPassword = newPassword;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "loginInfo_" + user.getUsername();
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/LoginInfo.java
+++ b/src/main/java/kernbeisser/Reports/LoginInfo.java
@@ -1,11 +1,10 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.User;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import kernbeisser.DBEntities.User;
 
 public class LoginInfo extends Report {
   private final User user;

--- a/src/main/java/kernbeisser/Reports/PermissionHolders.java
+++ b/src/main/java/kernbeisser/Reports/PermissionHolders.java
@@ -1,12 +1,11 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.Permission;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Permission;
 
 public class PermissionHolders extends Report {
   private final Collection<Permission> permissions;
@@ -14,13 +13,13 @@ public class PermissionHolders extends Report {
   public PermissionHolders(boolean withKeys) {
     super(ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME);
     permissions =
-            DBConnection.getEntityManager()
-                    .createQuery(
-                            "Select p from Permission p where not p.name in ('@IMPORT', '@APPLICATION', '@IN_RELATION_TO_OWN_USER'"
-                                    + (withKeys ? "" : ", '@Key_Permission', '@FULL_MEMBER' ,'@BASIC_ACCESS'")
-                                    + ")",
-                            Permission.class)
-                    .getResultList();
+        DBConnection.getEntityManager()
+            .createQuery(
+                "Select p from Permission p where not p.name in ('@IMPORT', '@APPLICATION', '@IN_RELATION_TO_OWN_USER'"
+                    + (withKeys ? "" : ", '@Key_Permission', '@FULL_MEMBER' ,'@BASIC_ACCESS'")
+                    + ")",
+                Permission.class)
+            .getResultList();
   }
 
   @Override
@@ -36,7 +35,7 @@ public class PermissionHolders extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return permissions.stream()
-            .flatMap(p -> PermissionHolderBean.createBeans(p).stream())
-            .collect(Collectors.toList());
+        .flatMap(p -> PermissionHolderBean.createBeans(p).stream())
+        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/PermissionHolders.java
+++ b/src/main/java/kernbeisser/Reports/PermissionHolders.java
@@ -1,25 +1,31 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Permission;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.Permission;
 
 public class PermissionHolders extends Report {
   private final Collection<Permission> permissions;
 
   public PermissionHolders(boolean withKeys) {
-    super("permissionHolders", "RollenInhaber" + LocalDate.now().toString());
+    super(ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME);
     permissions =
-        DBConnection.getEntityManager()
-            .createQuery(
-                "Select p from Permission p where not p.name in ('@IMPORT', '@APPLICATION', '@IN_RELATION_TO_OWN_USER'"
-                    + (withKeys ? "" : ", '@Key_Permission', '@FULL_MEMBER' ,'@BASIC_ACCESS'")
-                    + ")",
-                Permission.class)
-            .getResultList();
+            DBConnection.getEntityManager()
+                    .createQuery(
+                            "Select p from Permission p where not p.name in ('@IMPORT', '@APPLICATION', '@IN_RELATION_TO_OWN_USER'"
+                                    + (withKeys ? "" : ", '@Key_Permission', '@FULL_MEMBER' ,'@BASIC_ACCESS'")
+                                    + ")",
+                            Permission.class)
+                    .getResultList();
+  }
+
+  @Override
+  String createOutFileName() {
+    return "RollenInhaber" + LocalDate.now();
   }
 
   @Override
@@ -30,7 +36,7 @@ public class PermissionHolders extends Report {
   @Override
   Collection<?> getDetailCollection() {
     return permissions.stream()
-        .flatMap(p -> PermissionHolderBean.createBeans(p).stream())
-        .collect(Collectors.toList());
+            .flatMap(p -> PermissionHolderBean.createBeans(p).stream())
+            .collect(Collectors.toList());
   }
 }

--- a/src/main/java/kernbeisser/Reports/PreOrderChecklist.java
+++ b/src/main/java/kernbeisser/Reports/PreOrderChecklist.java
@@ -1,14 +1,13 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.PreOrder;
-import kernbeisser.DBEntities.User;
-
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.PreOrder;
+import kernbeisser.DBEntities.User;
 
 public class PreOrderChecklist extends Report {
   private final LocalDate deliveryDate;
@@ -18,10 +17,10 @@ public class PreOrderChecklist extends Report {
     super(ReportFileNames.PREORDER_CHECKLIST_REPORT_FILENAME);
     this.deliveryDate = deliveryDate;
     this.preorder =
-            preorder.stream()
-                    .filter(p -> !p.getUser().equals(User.getKernbeisserUser()))
-                    .sorted(Comparator.comparing(p -> p.getUser().getFullName(true)))
-                    .collect(Collectors.toList());
+        preorder.stream()
+            .filter(p -> !p.getUser().equals(User.getKernbeisserUser()))
+            .sorted(Comparator.comparing(p -> p.getUser().getFullName(true)))
+            .collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/PreOrderChecklist.java
+++ b/src/main/java/kernbeisser/Reports/PreOrderChecklist.java
@@ -1,27 +1,32 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.PreOrder;
+import kernbeisser.DBEntities.User;
+
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.swing.*;
-import kernbeisser.DBEntities.PreOrder;
-import kernbeisser.DBEntities.User;
 
 public class PreOrderChecklist extends Report {
   private final LocalDate deliveryDate;
   private final Collection<PreOrder> preorder;
 
   public PreOrderChecklist(LocalDate deliveryDate, Collection<PreOrder> preorder) {
-    super("preOrderChecklist", "preOrderChecklist" + LocalDate.now().toString());
+    super(ReportFileNames.PREORDER_CHECKLIST_REPORT_FILENAME);
     this.deliveryDate = deliveryDate;
     this.preorder =
-        preorder.stream()
-            .filter(p -> !p.getUser().equals(User.getKernbeisserUser()))
-            .sorted(Comparator.comparing(p -> p.getUser().getFullName(true)))
-            .collect(Collectors.toList());
+            preorder.stream()
+                    .filter(p -> !p.getUser().equals(User.getKernbeisserUser()))
+                    .sorted(Comparator.comparing(p -> p.getUser().getFullName(true)))
+                    .collect(Collectors.toList());
+  }
+
+  @Override
+  String createOutFileName() {
+    return "preOrderChecklist" + LocalDate.now();
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/PriceListReport.java
+++ b/src/main/java/kernbeisser/Reports/PriceListReport.java
@@ -1,15 +1,14 @@
 package kernbeisser.Reports;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 import kernbeisser.DBEntities.Article;
 import kernbeisser.DBEntities.Articles;
 import kernbeisser.DBEntities.PriceList;
 import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
 import lombok.var;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class PriceListReport extends Report {
   private final Collection<PriceListReportArticle> priceListReportArticles;
@@ -24,9 +23,9 @@ public class PriceListReport extends Report {
     setDuplexPrint(false);
     var lastDeliveries = Articles.getLastDeliveries();
     this.priceListReportArticles =
-            articles.stream()
-                    .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
-                    .collect(Collectors.toList());
+        articles.stream()
+            .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
+            .collect(Collectors.toList());
     this.priceListName = priceListName;
   }
 

--- a/src/main/java/kernbeisser/Reports/PriceListReport.java
+++ b/src/main/java/kernbeisser/Reports/PriceListReport.java
@@ -1,17 +1,17 @@
 package kernbeisser.Reports;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 import kernbeisser.DBEntities.Article;
 import kernbeisser.DBEntities.Articles;
 import kernbeisser.DBEntities.PriceList;
 import kernbeisser.Reports.ReportDTO.PriceListReportArticle;
 import lombok.var;
 
-public class PriceListReport extends Report {
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+public class PriceListReport extends Report {
   private final Collection<PriceListReportArticle> priceListReportArticles;
   private final String priceListName;
 
@@ -20,14 +20,19 @@ public class PriceListReport extends Report {
   }
 
   public PriceListReport(Collection<Article> articles, String priceListName) {
-    super("priceList", "Preisliste " + priceListName);
+    super(ReportFileNames.PRICELIST_REPORT_FILENAME);
     setDuplexPrint(false);
     var lastDeliveries = Articles.getLastDeliveries();
     this.priceListReportArticles =
-        articles.stream()
-            .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
-            .collect(Collectors.toList());
+            articles.stream()
+                    .map(a -> PriceListReportArticle.ofArticle(a, lastDeliveries))
+                    .collect(Collectors.toList());
     this.priceListName = priceListName;
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Preisliste " + priceListName;
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/Report.java
+++ b/src/main/java/kernbeisser/Reports/Report.java
@@ -1,5 +1,23 @@
 package kernbeisser.Reports;
 
+import java.awt.print.PrinterAbortException;
+import java.awt.print.PrinterJob;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Consumer;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.HashPrintServiceAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.PrintServiceAttributeSet;
+import javax.print.attribute.standard.MediaSizeName;
+import javax.print.attribute.standard.OrientationRequested;
+import javax.print.attribute.standard.PrinterName;
+import javax.print.attribute.standard.Sides;
+import javax.swing.*;
 import kernbeisser.Config.Config;
 import kernbeisser.Enums.Setting;
 import kernbeisser.Exeptions.NoTransactionsFoundException;
@@ -20,25 +38,6 @@ import net.sf.jasperreports.export.SimplePrintServiceExporterConfiguration;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.NotNull;
 
-import javax.print.attribute.HashPrintRequestAttributeSet;
-import javax.print.attribute.HashPrintServiceAttributeSet;
-import javax.print.attribute.PrintRequestAttributeSet;
-import javax.print.attribute.PrintServiceAttributeSet;
-import javax.print.attribute.standard.MediaSizeName;
-import javax.print.attribute.standard.OrientationRequested;
-import javax.print.attribute.standard.PrinterName;
-import javax.print.attribute.standard.Sides;
-import javax.swing.*;
-import java.awt.print.PrinterAbortException;
-import java.awt.print.PrinterJob;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Consumer;
-
 @Log4j2
 public abstract class Report {
 
@@ -57,18 +56,16 @@ public abstract class Report {
     this.reportFileName = reportFileName;
   }
 
-    abstract String createOutFileName();
+  abstract String createOutFileName();
 
-    JasperPrint lazyGetJspPrint() {
+  JasperPrint lazyGetJspPrint() {
     Map<String, Object> params = new HashMap<>();
     var reportParams = getReportParams();
     if (reportParams != null) params.putAll(reportParams);
     params.put("reportFooter", Setting.REPORT_FOOTLINE.getStringValue());
     try {
       return JasperFillManager.fillReport(
-          getJasperReport(),
-          params,
-          new JRBeanCollectionDataSource(getDetailCollection()));
+          getJasperReport(), params, new JRBeanCollectionDataSource(getDetailCollection()));
     } catch (JRException e) {
       if (ExceptionUtils.indexOfType(e.getCause(), PrinterAbortException.class) != -1) {
         Tools.showPrintAbortedWarning(e, true);
@@ -80,9 +77,10 @@ public abstract class Report {
   }
 
   private File getReportFile() {
-        log.debug("returning report file: {}", reportFileName);
-        return getReportsFolder().resolve(reportFileName).toAbsolutePath().toFile();
-    }
+    log.debug("returning report file: {}", reportFileName);
+    return getReportsFolder().resolve(reportFileName).toAbsolutePath().toFile();
+  }
+
   private JasperReport getJasperReport() throws JRException {
     JasperDesign jspDesign = JRXmlLoader.load(getReportFile());
     return JasperCompileManager.compileReport(jspDesign);
@@ -149,114 +147,114 @@ public abstract class Report {
                 requestAttributeSet.add(Sides.DUPLEX);
               }
 
-                    PrintServiceAttributeSet serviceAttributeSet =
-                            getPrinter(useOSDefaultPrinter, jasperPrint);
-                    SimplePrintServiceExporterConfiguration printConfig =
-                            new SimplePrintServiceExporterConfiguration();
-                    printConfig.setPrintRequestAttributeSet(requestAttributeSet);
-                    printConfig.setPrintServiceAttributeSet(serviceAttributeSet);
-                    printConfig.setDisplayPrintDialog(false);
-                    printConfig.setDisplayPageDialog(false);
-                    printExporter.setConfiguration(printConfig);
+              PrintServiceAttributeSet serviceAttributeSet =
+                  getPrinter(useOSDefaultPrinter, jasperPrint);
+              SimplePrintServiceExporterConfiguration printConfig =
+                  new SimplePrintServiceExporterConfiguration();
+              printConfig.setPrintRequestAttributeSet(requestAttributeSet);
+              printConfig.setPrintServiceAttributeSet(serviceAttributeSet);
+              printConfig.setDisplayPrintDialog(false);
+              printConfig.setDisplayPageDialog(false);
+              printExporter.setConfiguration(printConfig);
 
-                    try {
-                        printExporter.exportReport();
-                        pm.setNote("Fertig");
-                        pm.close();
-                    } catch (JRException e) {
-                        String errorMessage = e.getMessage().toLowerCase(Locale.ROOT);
-                        Collection<String> printerNotFoundMessages =
-                                Arrays.asList(
-                                        "not a 2d print service", // ubuntu
-                                        "no suitable print service found" // windows
-                                );
-                        if (printerNotFoundMessages.stream().anyMatch(errorMessage::contains)) {
-                            Main.logger.error(e.getMessage(), e);
-                            if (JOptionPane.showConfirmDialog(
-                                    null,
-                                    "Der konfigurierte Drucker \""
-                                            + serviceAttributeSet.get(PrinterName.class)
-                                            + "\"\nkann nicht gefunden werden!\n"
-                                            + "Soll stattdessen der Standarddrucker verwendet werden?",
-                                    "Drucken",
-                                    JOptionPane.OK_CANCEL_OPTION)
-                                    == JOptionPane.OK_OPTION) {
-                                sendToPrinter(true, message, duplexPrint, exConsumer);
-                            } else {
-                                Tools.showPrintAbortedWarning(e, false);
-                            }
-                        } else {
-                            exConsumer.accept(e);
-                        }
-                    }
-                })
-                .start();
+              try {
+                printExporter.exportReport();
+                pm.setNote("Fertig");
+                pm.close();
+              } catch (JRException e) {
+                String errorMessage = e.getMessage().toLowerCase(Locale.ROOT);
+                Collection<String> printerNotFoundMessages =
+                    Arrays.asList(
+                        "not a 2d print service", // ubuntu
+                        "no suitable print service found" // windows
+                        );
+                if (printerNotFoundMessages.stream().anyMatch(errorMessage::contains)) {
+                  Main.logger.error(e.getMessage(), e);
+                  if (JOptionPane.showConfirmDialog(
+                          null,
+                          "Der konfigurierte Drucker \""
+                              + serviceAttributeSet.get(PrinterName.class)
+                              + "\"\nkann nicht gefunden werden!\n"
+                              + "Soll stattdessen der Standarddrucker verwendet werden?",
+                          "Drucken",
+                          JOptionPane.OK_CANCEL_OPTION)
+                      == JOptionPane.OK_OPTION) {
+                    sendToPrinter(true, message, duplexPrint, exConsumer);
+                  } else {
+                    Tools.showPrintAbortedWarning(e, false);
+                  }
+                } else {
+                  exConsumer.accept(e);
+                }
+              }
+            })
+        .start();
+  }
+
+  public void exportPdf(String message, Consumer<Throwable> exConsumer) {
+
+    Path outputFolder = getOutputFolder();
+    if (!Files.exists(outputFolder)) {
+      try {
+        Files.createDirectories(outputFolder);
+      } catch (IOException e) {
+        Tools.showUnexpectedErrorWarning(e);
+      }
     }
+    Path filePath = getOutputFolder().resolve(getSafeOutFileName() + ".pdf").toAbsolutePath();
+    new Thread(
+            () -> {
+              ProgressMonitor pm =
+                  new ProgressMonitor(null, message, "Initialisiere Druckerservice...", 0, 2);
+              pm.setProgress(1);
+              pm.setNote("Exportiere PDF..");
+              try {
+                JasperExportManager.exportReportToPdfFile(getJspPrint(), filePath.toString());
+                pm.setNote("Fertig");
+                pm.close();
+                Tools.openFile(filePath.toFile());
+              } catch (JRException e) {
+                if (ExceptionUtils.indexOfType(e.getCause(), PrinterAbortException.class) != -1) {
+                  Tools.showPrintAbortedWarning(e, true);
+                } else {
+                  Tools.showUnexpectedErrorWarning(e);
+                }
+              } catch (Exception e) {
+                exConsumer.accept(e);
+              }
+            })
+        .start();
+  }
 
-    public void exportPdf(String message, Consumer<Throwable> exConsumer) {
-
-        Path outputFolder = getOutputFolder();
-        if (!Files.exists(outputFolder)) {
-            try {
-                Files.createDirectories(outputFolder);
-            } catch (IOException e) {
-                Tools.showUnexpectedErrorWarning(e);
-            }
-        }
-        Path filePath = getOutputFolder().resolve(getSafeOutFileName() + ".pdf").toAbsolutePath();
-        new Thread(
-                () -> {
-                    ProgressMonitor pm =
-                            new ProgressMonitor(null, message, "Initialisiere Druckerservice...", 0, 2);
-                    pm.setProgress(1);
-                    pm.setNote("Exportiere PDF..");
-                    try {
-                        JasperExportManager.exportReportToPdfFile(getJspPrint(), filePath.toString());
-                        pm.setNote("Fertig");
-                        pm.close();
-                        Tools.openFile(filePath.toFile());
-                    } catch (JRException e) {
-                        if (ExceptionUtils.indexOfType(e.getCause(), PrinterAbortException.class) != -1) {
-                            Tools.showPrintAbortedWarning(e, true);
-                        } else {
-                            Tools.showUnexpectedErrorWarning(e);
-                        }
-                    } catch (Exception e) {
-                        exConsumer.accept(e);
-                    }
-                })
-                .start();
+  public static void pdfExportException(Throwable e) {
+    try {
+      throw e;
+    } catch (FileNotFoundException f) {
+      Main.logger.error(e.getMessage(), e);
+      JOptionPane.showMessageDialog(
+          null,
+          "Die Datei kann nicht geschrieben werden,\nweil sie in einer anderen Anwendung geöffnet ist.\n"
+              + "Bitte die Datei schließen und den Export erneut aufrufen!\n",
+          "Fehler beim Dateizugriff",
+          JOptionPane.ERROR_MESSAGE);
+      throw new RuntimeException(f);
+    } catch (NoTransactionsFoundException n) {
+      JOptionPane.showMessageDialog(
+          null,
+          "Keine Bons gefunden, die den Kriterien entsprechen!",
+          "Keine Bons",
+          JOptionPane.ERROR_MESSAGE);
+    } catch (Throwable t) {
+      Tools.showUnexpectedErrorWarning(t);
     }
+  }
 
-    public static void pdfExportException(Throwable e) {
-        try {
-            throw e;
-        } catch (FileNotFoundException f) {
-            Main.logger.error(e.getMessage(), e);
-            JOptionPane.showMessageDialog(
-                    null,
-                    "Die Datei kann nicht geschrieben werden,\nweil sie in einer anderen Anwendung geöffnet ist.\n"
-                            + "Bitte die Datei schließen und den Export erneut aufrufen!\n",
-                    "Fehler beim Dateizugriff",
-                    JOptionPane.ERROR_MESSAGE);
-            throw new RuntimeException(f);
-        } catch (NoTransactionsFoundException n) {
-            JOptionPane.showMessageDialog(
-                    null,
-                    "Keine Bons gefunden, die den Kriterien entsprechen!",
-                    "Keine Bons",
-                    JOptionPane.ERROR_MESSAGE);
-        } catch (Throwable t) {
-            Tools.showUnexpectedErrorWarning(t);
-        }
-    }
+  @NotNull
+  private String getSafeOutFileName() {
+    return createOutFileName().replaceAll("[\\\\/:*?\"<>|]", "_");
+  }
 
-    @NotNull
-    private String getSafeOutFileName() {
-        return createOutFileName().replaceAll("[\\\\/:*?\"<>|]", "_");
-    }
+  abstract Map<String, Object> getReportParams();
 
-    abstract Map<String, Object> getReportParams();
-
-    abstract Collection<?> getDetailCollection();
+  abstract Collection<?> getDetailCollection();
 }

--- a/src/main/java/kernbeisser/Reports/ReportFileNames.java
+++ b/src/main/java/kernbeisser/Reports/ReportFileNames.java
@@ -4,23 +4,24 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ReportFileNames {
-    public final String ARTICLE_LABEL_REPORT_FILENAME = "Etiketten.jrxml";
-    public final String ACCOUNTING_TRANSACTION_REPORT_FILENAME = "BuchhaltungGuthabenAenderungen.jrxml";
-    public final String ACCOUNTING_REPORT_FILENAME = "BuchhaltungBonUebersicht.jrxml";
-    public final String INVENTORY_COUNTING_LISTS_REPORT_FILENAME = "Inventur_Zaehlliste.jrxml";
-    public final String INVOICE_REPORT_FILENAME = "Kerni_Rechnung.jrxml";
-    public final String KEY_USER_LIST_REPORT_FILENAME = "BenutzerSchluessel.jrxml";
-    public final String PREORDER_CHECKLIST_REPORT_FILENAME = "Abhakplan.jrxml";
-    public final String PRICELIST_REPORT_FILENAME = "Preisliste.jrxml";
-    public final String TRANSACTION_STATEMENT_REPORT_FILENAME = "Kontoauszug.jrxml";
-    public final String TRIAL_MEMBER_REPORT_FILENAME = "Probemitglieder.jrxml";
-    public final String USER_BALANCE_REPORT_FILENAME = "GuthabenUebersicht.jrxml";
-    public final String TILLROLL_REPORT_FILENAME = "Bonrolle.jrxml";
-    public final String LOGININFO_REPORT_FILENAME = "LoginInformation.jrxml";
-    public final String PERMISSION_HOLDERS_REPORT_FILENAME = "RollenInhaber.jrxml";
+  public final String ARTICLE_LABEL_REPORT_FILENAME = "Etiketten.jrxml";
+  public final String ACCOUNTING_TRANSACTION_REPORT_FILENAME =
+      "BuchhaltungGuthabenAenderungen.jrxml";
+  public final String ACCOUNTING_REPORT_FILENAME = "BuchhaltungBonUebersicht.jrxml";
+  public final String INVENTORY_COUNTING_LISTS_REPORT_FILENAME = "Inventur_Zaehlliste.jrxml";
+  public final String INVOICE_REPORT_FILENAME = "Kerni_Rechnung.jrxml";
+  public final String KEY_USER_LIST_REPORT_FILENAME = "BenutzerSchluessel.jrxml";
+  public final String PREORDER_CHECKLIST_REPORT_FILENAME = "Abhakplan.jrxml";
+  public final String PRICELIST_REPORT_FILENAME = "Preisliste.jrxml";
+  public final String TRANSACTION_STATEMENT_REPORT_FILENAME = "Kontoauszug.jrxml";
+  public final String TRIAL_MEMBER_REPORT_FILENAME = "Probemitglieder.jrxml";
+  public final String USER_BALANCE_REPORT_FILENAME = "GuthabenUebersicht.jrxml";
+  public final String TILLROLL_REPORT_FILENAME = "Bonrolle.jrxml";
+  public final String LOGININFO_REPORT_FILENAME = "LoginInformation.jrxml";
+  public final String PERMISSION_HOLDERS_REPORT_FILENAME = "RollenInhaber.jrxml";
 
-    public static String INVENTORY_SHELF_DETAILS_REPORT_FILENAME = "Inventur_Regaldetails.jrxml";
-    public static String INVENTORY_SHELF_OVERVIEW_REPORT_FILENAME = "Inventur_Regaluebersicht.jrxml";
-    public static String INVENTORY_SHELF_STOCKS = "Inventur_Regal_Bestaende.jrxml";
-    public static String INVENTORY_STOCKS = "Inventur_Bestaende.jrxml";
+  public static String INVENTORY_SHELF_DETAILS_REPORT_FILENAME = "Inventur_Regaldetails.jrxml";
+  public static String INVENTORY_SHELF_OVERVIEW_REPORT_FILENAME = "Inventur_Regaluebersicht.jrxml";
+  public static String INVENTORY_SHELF_STOCKS = "Inventur_Regal_Bestaende.jrxml";
+  public static String INVENTORY_STOCKS = "Inventur_Bestaende.jrxml";
 }

--- a/src/main/java/kernbeisser/Reports/ReportFileNames.java
+++ b/src/main/java/kernbeisser/Reports/ReportFileNames.java
@@ -1,0 +1,26 @@
+package kernbeisser.Reports;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ReportFileNames {
+    public final String ARTICLE_LABEL_REPORT_FILENAME = "Etiketten.jrxml";
+    public final String ACCOUNTING_TRANSACTION_REPORT_FILENAME = "BuchhaltungGuthabenAenderungen.jrxml";
+    public final String ACCOUNTING_REPORT_FILENAME = "BuchhaltungBonUebersicht.jrxml";
+    public final String INVENTORY_COUNTING_LISTS_REPORT_FILENAME = "Inventur_Zaehlliste.jrxml";
+    public final String INVOICE_REPORT_FILENAME = "Kerni_Rechnung.jrxml";
+    public final String KEY_USER_LIST_REPORT_FILENAME = "BenutzerSchluessel.jrxml";
+    public final String PREORDER_CHECKLIST_REPORT_FILENAME = "Abhakplan.jrxml";
+    public final String PRICELIST_REPORT_FILENAME = "Preisliste.jrxml";
+    public final String TRANSACTION_STATEMENT_REPORT_FILENAME = "Kontoauszug.jrxml";
+    public final String TRIAL_MEMBER_REPORT_FILENAME = "Probemitglieder.jrxml";
+    public final String USER_BALANCE_REPORT_FILENAME = "GuthabenUebersicht.jrxml";
+    public final String TILLROLL_REPORT_FILENAME = "Bonrolle.jrxml";
+    public final String LOGININFO_REPORT_FILENAME = "LoginInformation.jrxml";
+    public final String PERMISSION_HOLDERS_REPORT_FILENAME = "RollenInhaber.jrxml";
+
+    public static String INVENTORY_SHELF_DETAILS_REPORT_FILENAME = "Inventur_Regaldetails.jrxml";
+    public static String INVENTORY_SHELF_OVERVIEW_REPORT_FILENAME = "Inventur_Regaluebersicht.jrxml";
+    public static String INVENTORY_SHELF_STOCKS = "Inventur_Regal_Bestaende.jrxml";
+    public static String INVENTORY_STOCKS = "Inventur_Bestaende.jrxml";
+}

--- a/src/main/java/kernbeisser/Reports/TillrollReport.java
+++ b/src/main/java/kernbeisser/Reports/TillrollReport.java
@@ -1,17 +1,16 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.ShoppingItem;
-import lombok.Cleanup;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.ShoppingItem;
+import lombok.Cleanup;
 
 public class TillrollReport extends Report {
   private final Instant start;
@@ -25,7 +24,8 @@ public class TillrollReport extends Report {
 
   @Override
   String createOutFileName() {
-    return String.format("KernbeisserBonrolle_%s_%s", Timestamp.from(start), Timestamp.from(endExclusive));
+    return String.format(
+        "KernbeisserBonrolle_%s_%s", Timestamp.from(start), Timestamp.from(endExclusive));
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/TillrollReport.java
+++ b/src/main/java/kernbeisser/Reports/TillrollReport.java
@@ -1,30 +1,31 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.ShoppingItem;
+import lombok.Cleanup;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.ShoppingItem;
-import lombok.Cleanup;
 
 public class TillrollReport extends Report {
-
   private final Instant start;
   private final Instant endExclusive;
 
   public TillrollReport(Instant start, Instant endExclusive) {
-    super(
-        "tillrollFileName",
-        String.format(
-            "KernbeisserBonrolle_%s_%s",
-            Timestamp.from(start).toString(), Timestamp.from(endExclusive).toString()));
+    super(ReportFileNames.TILLROLL_REPORT_FILENAME);
     this.start = start;
     this.endExclusive = endExclusive;
+  }
+
+  @Override
+  String createOutFileName() {
+    return String.format("KernbeisserBonrolle_%s_%s", Timestamp.from(start), Timestamp.from(endExclusive));
   }
 
   @Override

--- a/src/main/java/kernbeisser/Reports/TransactionStatement.java
+++ b/src/main/java/kernbeisser/Reports/TransactionStatement.java
@@ -1,14 +1,5 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBConnection.DBConnection;
-import kernbeisser.DBEntities.Transaction;
-import kernbeisser.DBEntities.User;
-import kernbeisser.DBEntities.UserGroup;
-import kernbeisser.Enums.StatementType;
-import lombok.Cleanup;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -16,6 +7,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.DBEntities.UserGroup;
+import kernbeisser.Enums.StatementType;
+import lombok.Cleanup;
 
 public class TransactionStatement extends Report {
   private final UserGroup userGroup;
@@ -71,11 +70,11 @@ public class TransactionStatement extends Report {
     EntityTransaction et = em.getTransaction();
     et.begin();
     userTransactions =
-            em.createQuery(
-                            "select t from Transaction t where :ug IN (fromUserGroup.id, toUserGroup.id)",
-                            Transaction.class)
-                    .setParameter("ug", userGroup.getId())
-                    .getResultList();
+        em.createQuery(
+                "select t from Transaction t where :ug IN (fromUserGroup.id, toUserGroup.id)",
+                Transaction.class)
+            .setParameter("ug", userGroup.getId())
+            .getResultList();
   }
 
   @Override
@@ -87,32 +86,32 @@ public class TransactionStatement extends Report {
   Map<String, Object> getReportParams() {
     Map<String, Object> params = new HashMap<>();
     double startValue =
-            userTransactions.stream()
-                    .filter(t -> t.getDate().isBefore(startDate.toInstant()))
-                    .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
-                    .reduce(Double::sum)
-                    .orElse(0.0);
+        userTransactions.stream()
+            .filter(t -> t.getDate().isBefore(startDate.toInstant()))
+            .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
+            .reduce(Double::sum)
+            .orElse(0.0);
     double endValue =
-            userTransactions.stream()
-                    .filter(t -> !t.getDate().isAfter(endDate.toInstant()))
-                    .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
-                    .reduce(Double::sum)
-                    .orElse(0.0);
+        userTransactions.stream()
+            .filter(t -> !t.getDate().isAfter(endDate.toInstant()))
+            .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
+            .reduce(Double::sum)
+            .orElse(0.0);
     params.put(
-            "userName",
-            user == null
-                    ? userGroup.getMembersAsString() + "(" + userGroup.getId() + ")"
-                    : user.getFullName());
+        "userName",
+        user == null
+            ? userGroup.getMembersAsString() + "(" + userGroup.getId() + ")"
+            : user.getFullName());
     params.put("userGroup", userGroup);
     params.put("startValue", startValue);
     params.put("endValue", endValue);
     String stType = statementType.toString();
     params.put(
-            "statementType",
-            (!current && statementType != StatementType.FULL
-                    ? "Vor" + stType.substring(0, 1).toLowerCase()
-                    : stType.substring(0, 1))
-                    + stType.substring(1));
+        "statementType",
+        (!current && statementType != StatementType.FULL
+                ? "Vor" + stType.substring(0, 1).toLowerCase()
+                : stType.substring(0, 1))
+            + stType.substring(1));
     return params;
   }
 

--- a/src/main/java/kernbeisser/Reports/TransactionStatement.java
+++ b/src/main/java/kernbeisser/Reports/TransactionStatement.java
@@ -1,14 +1,5 @@
 package kernbeisser.Reports;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
-import javax.persistence.EntityTransaction;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.Transaction;
 import kernbeisser.DBEntities.User;
@@ -16,8 +7,17 @@ import kernbeisser.DBEntities.UserGroup;
 import kernbeisser.Enums.StatementType;
 import lombok.Cleanup;
 
-public class TransactionStatement extends Report {
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+public class TransactionStatement extends Report {
   private final UserGroup userGroup;
   private final User user;
   private final StatementType statementType;
@@ -32,9 +32,7 @@ public class TransactionStatement extends Report {
 
   public TransactionStatement(
       UserGroup userGroup, User user, StatementType statementType, boolean current) {
-    super(
-        "transactionStatement",
-        "Kontoauszug_" + (user == null ? String.valueOf(userGroup.getId()) : user.toString()));
+    super(ReportFileNames.TRANSACTION_STATEMENT_REPORT_FILENAME);
     this.userGroup = userGroup;
     this.user = user;
     this.statementType = statementType;
@@ -73,43 +71,48 @@ public class TransactionStatement extends Report {
     EntityTransaction et = em.getTransaction();
     et.begin();
     userTransactions =
-        em.createQuery(
-                "select t from Transaction t where :ug IN (fromUserGroup.id, toUserGroup.id)",
-                Transaction.class)
-            .setParameter("ug", userGroup.getId())
-            .getResultList();
+            em.createQuery(
+                            "select t from Transaction t where :ug IN (fromUserGroup.id, toUserGroup.id)",
+                            Transaction.class)
+                    .setParameter("ug", userGroup.getId())
+                    .getResultList();
+  }
+
+  @Override
+  String createOutFileName() {
+    return "Kontoauszug_" + (user == null ? String.valueOf(userGroup.getId()) : user.toString());
   }
 
   @Override
   Map<String, Object> getReportParams() {
     Map<String, Object> params = new HashMap<>();
     double startValue =
-        userTransactions.stream()
-            .filter(t -> t.getDate().isBefore(startDate.toInstant()))
-            .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
-            .reduce(Double::sum)
-            .orElse(0.0);
+            userTransactions.stream()
+                    .filter(t -> t.getDate().isBefore(startDate.toInstant()))
+                    .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
+                    .reduce(Double::sum)
+                    .orElse(0.0);
     double endValue =
-        userTransactions.stream()
-            .filter(t -> !t.getDate().isAfter(endDate.toInstant()))
-            .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
-            .reduce(Double::sum)
-            .orElse(0.0);
+            userTransactions.stream()
+                    .filter(t -> !t.getDate().isAfter(endDate.toInstant()))
+                    .mapToDouble(t -> (t.getFromUserGroup().equals(userGroup) ? -1.0 : 1.0) * t.getValue())
+                    .reduce(Double::sum)
+                    .orElse(0.0);
     params.put(
-        "userName",
-        user == null
-            ? userGroup.getMembersAsString() + "(" + userGroup.getId() + ")"
-            : user.getFullName());
+            "userName",
+            user == null
+                    ? userGroup.getMembersAsString() + "(" + userGroup.getId() + ")"
+                    : user.getFullName());
     params.put("userGroup", userGroup);
     params.put("startValue", startValue);
     params.put("endValue", endValue);
     String stType = statementType.toString();
     params.put(
-        "statementType",
-        (!current && statementType != StatementType.FULL
-                ? "Vor" + stType.substring(0, 1).toLowerCase()
-                : stType.substring(0, 1))
-            + stType.substring(1));
+            "statementType",
+            (!current && statementType != StatementType.FULL
+                    ? "Vor" + stType.substring(0, 1).toLowerCase()
+                    : stType.substring(0, 1))
+                    + stType.substring(1));
     return params;
   }
 

--- a/src/main/java/kernbeisser/Reports/TrialMemberReport.java
+++ b/src/main/java/kernbeisser/Reports/TrialMemberReport.java
@@ -1,29 +1,32 @@
 package kernbeisser.Reports;
 
-import java.time.Instant;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import kernbeisser.Enums.Setting;
 import kernbeisser.Reports.ReportDTO.TrialMemberReportEntry;
 import kernbeisser.Useful.Date;
 
-public class TrialMemberReport extends Report {
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+public class TrialMemberReport extends Report {
   public TrialMemberReport() {
-    super(
-        "trialMemberReportFileName",
-        String.format("Probemitlieder_%s", Date.INSTANT_DATE.format(Instant.now())));
+    super(ReportFileNames.TRIAL_MEMBER_REPORT_FILENAME);
+  }
+
+  @Override
+  String createOutFileName() {
+    return String.format("Probemitlieder_%s", Date.INSTANT_DATE.format(Instant.now()));
   }
 
   @Override
   Map<String, Object> getReportParams() {
     Map<String, Object> params = new HashMap<>();
     params.put(
-        "title",
-        Setting.STORE_NAME.getStringValue()
-            + " Probemitglieder Stand: "
-            + Date.INSTANT_DATE.format(Instant.now()));
+            "title",
+            Setting.STORE_NAME.getStringValue()
+                    + " Probemitglieder Stand: "
+                    + Date.INSTANT_DATE.format(Instant.now()));
     return params;
   }
 

--- a/src/main/java/kernbeisser/Reports/TrialMemberReport.java
+++ b/src/main/java/kernbeisser/Reports/TrialMemberReport.java
@@ -1,13 +1,12 @@
 package kernbeisser.Reports;
 
-import kernbeisser.Enums.Setting;
-import kernbeisser.Reports.ReportDTO.TrialMemberReportEntry;
-import kernbeisser.Useful.Date;
-
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import kernbeisser.Enums.Setting;
+import kernbeisser.Reports.ReportDTO.TrialMemberReportEntry;
+import kernbeisser.Useful.Date;
 
 public class TrialMemberReport extends Report {
   public TrialMemberReport() {
@@ -23,10 +22,10 @@ public class TrialMemberReport extends Report {
   Map<String, Object> getReportParams() {
     Map<String, Object> params = new HashMap<>();
     params.put(
-            "title",
-            Setting.STORE_NAME.getStringValue()
-                    + " Probemitglieder Stand: "
-                    + Date.INSTANT_DATE.format(Instant.now()));
+        "title",
+        Setting.STORE_NAME.getStringValue()
+            + " Probemitglieder Stand: "
+            + Date.INSTANT_DATE.format(Instant.now()));
     return params;
   }
 

--- a/src/main/java/kernbeisser/Reports/UserBalanceReport.java
+++ b/src/main/java/kernbeisser/Reports/UserBalanceReport.java
@@ -1,13 +1,14 @@
 package kernbeisser.Reports;
 
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.DBEntities.UserGroup;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
-import kernbeisser.DBEntities.Transaction;
-import kernbeisser.DBEntities.User;
-import kernbeisser.DBEntities.UserGroup;
 
 public class UserBalanceReport extends Report {
   final Timestamp timeStamp;
@@ -16,26 +17,28 @@ public class UserBalanceReport extends Report {
   private final long reportNo;
 
   public UserBalanceReport(long reportNo, boolean withNames) {
-    super(
-        "userBalanceFileName",
-        String.format(
-            "KernbeisserGuthabenstände_%s",
-            (reportNo == -1
-                ? Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)).toString()
-                : reportNo)));
+    super(ReportFileNames.USER_BALANCE_REPORT_FILENAME);
     this.reportNo = reportNo;
     this.withNames = withNames;
     this.timeStamp = Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES));
     this.userGroups = getUserGroups();
   }
 
+  @Override
+  String createOutFileName() {
+    return String.format(
+            "KernbeisserGuthabenstände_%s",
+            (reportNo == -1
+                    ? Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)).toString()
+                    : reportNo));
+  }
+
   private List<UserGroup> getUserGroups() {
     List<UserGroup> userGroups;
     final Map<UserGroup, Double> historicUserGroupValues =
-        reportNo == -1
-            ? new HashMap<>()
-            : UserGroup.getValueMapAtTransactionId(Transaction.getLastIdOfReportNo(reportNo), true);
-    ;
+            reportNo == -1
+                    ? new HashMap<>()
+                    : UserGroup.getValueMapAtTransactionId(Transaction.getLastIdOfReportNo(reportNo), true);
     if (reportNo == -1) {
       userGroups = UserGroup.getActiveUserGroups();
     } else {

--- a/src/main/java/kernbeisser/Reports/UserBalanceReport.java
+++ b/src/main/java/kernbeisser/Reports/UserBalanceReport.java
@@ -1,14 +1,13 @@
 package kernbeisser.Reports;
 
-import kernbeisser.DBEntities.Transaction;
-import kernbeisser.DBEntities.User;
-import kernbeisser.DBEntities.UserGroup;
-
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.DBEntities.UserGroup;
 
 public class UserBalanceReport extends Report {
   final Timestamp timeStamp;
@@ -27,18 +26,18 @@ public class UserBalanceReport extends Report {
   @Override
   String createOutFileName() {
     return String.format(
-            "KernbeisserGuthabenstände_%s",
-            (reportNo == -1
-                    ? Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)).toString()
-                    : reportNo));
+        "KernbeisserGuthabenstände_%s",
+        (reportNo == -1
+            ? Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES)).toString()
+            : reportNo));
   }
 
   private List<UserGroup> getUserGroups() {
     List<UserGroup> userGroups;
     final Map<UserGroup, Double> historicUserGroupValues =
-            reportNo == -1
-                    ? new HashMap<>()
-                    : UserGroup.getValueMapAtTransactionId(Transaction.getLastIdOfReportNo(reportNo), true);
+        reportNo == -1
+            ? new HashMap<>()
+            : UserGroup.getValueMapAtTransactionId(Transaction.getLastIdOfReportNo(reportNo), true);
     if (reportNo == -1) {
       userGroups = UserGroup.getActiveUserGroups();
     } else {

--- a/src/test/java/kernbeisser/Reports/AccountingReportTest.java
+++ b/src/test/java/kernbeisser/Reports/AccountingReportTest.java
@@ -1,5 +1,13 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.*;
 import kernbeisser.Enums.TransactionType;
@@ -12,112 +20,108 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.persistence.EntityManager;
-import javax.persistence.Tuple;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.util.Collections;
-import java.util.List;
-
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class AccountingReportTest {
-    @Test
-    void lazyGetJspPrint() {
+  @Test
+  void lazyGetJspPrint() {
 
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
 
-            Purchase purchase = createPurchase();
-            mockQuerys(entityManagerMock, purchase);
+      Purchase purchase = createPurchase();
+      mockQuerys(entityManagerMock, purchase);
 
-            List<Transaction> transactions = createTransactions();
-            AccountingReport accountingReport = new AccountingReport(1L, transactions, false);
+      List<Transaction> transactions = createTransactions();
+      AccountingReport accountingReport = new AccountingReport(1L, transactions, false);
 
-            // act
-            JasperPrint jspPrint = accountingReport.lazyGetJspPrint();
+      // act
+      JasperPrint jspPrint = accountingReport.lazyGetJspPrint();
 
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.ACCOUNTING_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.ACCOUNTING_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @Test
-    void createOutFileName() {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            mockPurchaseQuery(entityManagerMock, new Purchase());
+  @Test
+  void createOutFileName() {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      mockPurchaseQuery(entityManagerMock, new Purchase());
 
-            AccountingReport accountingReport = new AccountingReport(1337L, null, false);
+      AccountingReport accountingReport = new AccountingReport(1337L, null, false);
 
-            // act
-            String result = accountingReport.createOutFileName();
+      // act
+      String result = accountingReport.createOutFileName();
 
-            // assert
-            Assertions.assertEquals("KernbeisserBuchhaltungBonUebersicht_1337", result);
-        }
+      // assert
+      Assertions.assertEquals("KernbeisserBuchhaltungBonUebersicht_1337", result);
     }
+  }
 
-    private static void mockQuerys(EntityManager entityManagerMock, @NotNull Purchase purchase) {
-        TypedQuery typedQueryShoppingItem = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryShoppingItem);
+  private static void mockQuerys(EntityManager entityManagerMock, @NotNull Purchase purchase) {
+    TypedQuery typedQueryShoppingItem = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class)))
+        .thenReturn(typedQueryShoppingItem);
 
-        mockPurchaseQuery(entityManagerMock, purchase);
-        mockSupplierQuery(entityManagerMock);
-        mockUserQuery(entityManagerMock);
-        mockTupleQuery(entityManagerMock);
-    }
+    mockPurchaseQuery(entityManagerMock, purchase);
+    mockSupplierQuery(entityManagerMock);
+    mockUserQuery(entityManagerMock);
+    mockTupleQuery(entityManagerMock);
+  }
 
-    private static void mockTupleQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultStream()).thenReturn(EntityManagerMockHelper.getStream(new UserGroup()));
-    }
+  private static void mockTupleQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultStream())
+        .thenReturn(EntityManagerMockHelper.getStream(new UserGroup()));
+  }
 
-    private static void mockPurchaseQuery(EntityManager entityManagerMock, @NotNull Purchase purchase) {
-        TypedQuery<Purchase> typedQueryPurchase = Mockito.mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Purchase.class))).thenReturn(typedQueryPurchase);
-        when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
-        when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(purchase));
-    }
+  private static void mockPurchaseQuery(
+      EntityManager entityManagerMock, @NotNull Purchase purchase) {
+    TypedQuery<Purchase> typedQueryPurchase = Mockito.mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Purchase.class)))
+        .thenReturn(typedQueryPurchase);
+    when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
+    when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(purchase));
+  }
 
-    @NotNull
-    private static Purchase createPurchase() {
-        Purchase purchase = new Purchase();
-        SaleSession saleSession = mock(SaleSession.class);
-        when(saleSession.getSeller()).thenReturn(new User());
-        when(saleSession.getCustomer()).thenReturn(new User());
-        purchase.setSession(saleSession);
-        return purchase;
-    }
+  @NotNull
+  private static Purchase createPurchase() {
+    Purchase purchase = new Purchase();
+    SaleSession saleSession = mock(SaleSession.class);
+    when(saleSession.getSeller()).thenReturn(new User());
+    when(saleSession.getCustomer()).thenReturn(new User());
+    purchase.setSession(saleSession);
+    return purchase;
+  }
 
-    private static void mockSupplierQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQuerySupplier = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Supplier.class))).thenReturn(typedQuerySupplier);
-        when(typedQuerySupplier.setParameter(anyString(), any())).thenReturn(typedQuerySupplier);
-        when(typedQuerySupplier.getSingleResult()).thenReturn(new Supplier());
-    }
+  private static void mockSupplierQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQuerySupplier = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Supplier.class)))
+        .thenReturn(typedQuerySupplier);
+    when(typedQuerySupplier.setParameter(anyString(), any())).thenReturn(typedQuerySupplier);
+    when(typedQuerySupplier.getSingleResult()).thenReturn(new Supplier());
+  }
 
-    private static void mockUserQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryUser = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
-        when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
-        when(typedQueryUser.getSingleResult()).thenReturn(new User());
-    }
+  private static void mockUserQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryUser = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
+    when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
+    when(typedQueryUser.getSingleResult()).thenReturn(new User());
+  }
 
-    @NotNull
-    private static List<Transaction> createTransactions() {
-        Transaction transaction = new Transaction();
-        transaction.setFromUser(new User());
-        transaction.setToUser(new User());
-        transaction.setTransactionType(TransactionType.PURCHASE);
-        transaction.setDate(Instant.now());
-        return Collections.singletonList(transaction);
-    }
-
+  @NotNull
+  private static List<Transaction> createTransactions() {
+    Transaction transaction = new Transaction();
+    transaction.setFromUser(new User());
+    transaction.setToUser(new User());
+    transaction.setTransactionType(TransactionType.PURCHASE);
+    transaction.setDate(Instant.now());
+    return Collections.singletonList(transaction);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/AccountingReportTest.java
+++ b/src/test/java/kernbeisser/Reports/AccountingReportTest.java
@@ -1,0 +1,123 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.*;
+import kernbeisser.Enums.TransactionType;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Tuple;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountingReportTest {
+    @Test
+    void lazyGetJspPrint() {
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+
+            Purchase purchase = createPurchase();
+            mockQuerys(entityManagerMock, purchase);
+
+            List<Transaction> transactions = createTransactions();
+            AccountingReport accountingReport = new AccountingReport(1L, transactions, false);
+
+            // act
+            JasperPrint jspPrint = accountingReport.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.ACCOUNTING_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    @Test
+    void createOutFileName() {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            mockPurchaseQuery(entityManagerMock, new Purchase());
+
+            AccountingReport accountingReport = new AccountingReport(1337L, null, false);
+
+            // act
+            String result = accountingReport.createOutFileName();
+
+            // assert
+            Assertions.assertEquals("KernbeisserBuchhaltungBonUebersicht_1337", result);
+        }
+    }
+
+    private static void mockQuerys(EntityManager entityManagerMock, @NotNull Purchase purchase) {
+        TypedQuery typedQueryShoppingItem = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryShoppingItem);
+
+        mockPurchaseQuery(entityManagerMock, purchase);
+        mockSupplierQuery(entityManagerMock);
+        mockUserQuery(entityManagerMock);
+        mockTupleQuery(entityManagerMock);
+    }
+
+    private static void mockTupleQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultStream()).thenReturn(EntityManagerMockHelper.getStream(new UserGroup()));
+    }
+
+    private static void mockPurchaseQuery(EntityManager entityManagerMock, @NotNull Purchase purchase) {
+        TypedQuery<Purchase> typedQueryPurchase = Mockito.mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Purchase.class))).thenReturn(typedQueryPurchase);
+        when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
+        when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(purchase));
+    }
+
+    @NotNull
+    private static Purchase createPurchase() {
+        Purchase purchase = new Purchase();
+        SaleSession saleSession = mock(SaleSession.class);
+        when(saleSession.getSeller()).thenReturn(new User());
+        when(saleSession.getCustomer()).thenReturn(new User());
+        purchase.setSession(saleSession);
+        return purchase;
+    }
+
+    private static void mockSupplierQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQuerySupplier = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Supplier.class))).thenReturn(typedQuerySupplier);
+        when(typedQuerySupplier.setParameter(anyString(), any())).thenReturn(typedQuerySupplier);
+        when(typedQuerySupplier.getSingleResult()).thenReturn(new Supplier());
+    }
+
+    private static void mockUserQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryUser = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
+        when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
+        when(typedQueryUser.getSingleResult()).thenReturn(new User());
+    }
+
+    @NotNull
+    private static List<Transaction> createTransactions() {
+        Transaction transaction = new Transaction();
+        transaction.setFromUser(new User());
+        transaction.setToUser(new User());
+        transaction.setTransactionType(TransactionType.PURCHASE);
+        transaction.setDate(Instant.now());
+        return Collections.singletonList(transaction);
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/AccountingTransactionsReportTest.java
+++ b/src/test/java/kernbeisser/Reports/AccountingTransactionsReportTest.java
@@ -1,5 +1,12 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.Transaction;
 import kernbeisser.DBEntities.User;
@@ -10,64 +17,59 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 class AccountingTransactionsReportTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        AccountingTransactionsReport report = new AccountingTransactionsReport(1337L, null, UserNameObfuscation.NONE, true);
+  @Test
+  void createOutFileName() {
+    // arrange
+    AccountingTransactionsReport report =
+        new AccountingTransactionsReport(1337L, null, UserNameObfuscation.NONE, true);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("KernbeisserBuchhaltungEinSonderzahlungen_1337", result);
+    // assert
+    Assertions.assertEquals("KernbeisserBuchhaltungEinSonderzahlungen_1337", result);
+  }
+
+  @Test
+  void lazyGetJspPrint() throws MissingFullMemberException {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      Transaction transaction = createTransaction();
+
+      // act
+      Report report =
+          new AccountingTransactionsReport(
+              1337L, Collections.singletonList(transaction), UserNameObfuscation.NONE, true);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+
+      // FIXME
+      // Assertions.assertEquals(ReportFileNames.ACCOUNTING_TRANSACTION_REPORT_FILENAME,
+      // jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() throws MissingFullMemberException {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
+  @NotNull
+  private static Transaction createTransaction() {
+    Transaction transaction = mock(Transaction.class);
+    when(transaction.getDate()).thenReturn(Instant.now());
+    when(transaction.withUserIdentifications(any())).thenReturn(mock(Transaction.class));
+    return transaction;
+  }
 
-            Transaction transaction = createTransaction();
-
-            // act
-            Report report = new AccountingTransactionsReport(1337L, Collections.singletonList(transaction), UserNameObfuscation.NONE, true);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-
-            // FIXME
-            // Assertions.assertEquals(ReportFileNames.ACCOUNTING_TRANSACTION_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    @NotNull
-    private static Transaction createTransaction() {
-        Transaction transaction = mock(Transaction.class);
-        when(transaction.getDate()).thenReturn(Instant.now());
-        when(transaction.withUserIdentifications(any())).thenReturn(mock(Transaction.class));
-        return transaction;
-    }
-
-    private static void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryUser = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
-        when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
-        when(typedQueryUser.getSingleResult()).thenReturn(new User());
-    }
-
+  private static void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryUser = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
+    when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
+    when(typedQueryUser.getSingleResult()).thenReturn(new User());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/AccountingTransactionsReportTest.java
+++ b/src/test/java/kernbeisser/Reports/AccountingTransactionsReportTest.java
@@ -1,0 +1,73 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.Exeptions.MissingFullMemberException;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class AccountingTransactionsReportTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        AccountingTransactionsReport report = new AccountingTransactionsReport(1337L, null, UserNameObfuscation.NONE, true);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("KernbeisserBuchhaltungEinSonderzahlungen_1337", result);
+    }
+
+    @Test
+    void lazyGetJspPrint() throws MissingFullMemberException {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            Transaction transaction = createTransaction();
+
+            // act
+            Report report = new AccountingTransactionsReport(1337L, Collections.singletonList(transaction), UserNameObfuscation.NONE, true);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+
+            // FIXME
+            // Assertions.assertEquals(ReportFileNames.ACCOUNTING_TRANSACTION_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    @NotNull
+    private static Transaction createTransaction() {
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getDate()).thenReturn(Instant.now());
+        when(transaction.withUserIdentifications(any())).thenReturn(mock(Transaction.class));
+        return transaction;
+    }
+
+    private static void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryUser = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryUser);
+        when(typedQueryUser.setMaxResults(anyInt())).thenReturn(typedQueryUser);
+        when(typedQueryUser.getSingleResult()).thenReturn(new User());
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/ArticleLabelTest.java
+++ b/src/test/java/kernbeisser/Reports/ArticleLabelTest.java
@@ -1,0 +1,24 @@
+package kernbeisser.Reports;
+
+import kernbeisser.Useful.Date;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+class ArticleLabelTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        Report report = new ArticleLabel(null);
+        String now = Date.INSTANT_DATE_TIME.format(Instant.now());
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Etiketten_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/ArticleLabelTest.java
+++ b/src/test/java/kernbeisser/Reports/ArticleLabelTest.java
@@ -1,24 +1,22 @@
 package kernbeisser.Reports;
 
+import java.time.Instant;
 import kernbeisser.Useful.Date;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
-
 class ArticleLabelTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        Report report = new ArticleLabel(null);
-        String now = Date.INSTANT_DATE_TIME.format(Instant.now());
+  @Test
+  void createOutFileName() {
+    // arrange
+    Report report = new ArticleLabel(null);
+    String now = Date.INSTANT_DATE_TIME.format(Instant.now());
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Etiketten_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("Etiketten_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/EntityManagerMockHelper.java
+++ b/src/test/java/kernbeisser/Reports/EntityManagerMockHelper.java
@@ -1,5 +1,13 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.persistence.*;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.SettingValue;
 import kernbeisser.DBEntities.UserGroup;
@@ -8,87 +16,84 @@ import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import javax.persistence.*;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Stream;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 public class EntityManagerMockHelper {
-    @NotNull
-    static EntityManager mockEntityManager(MockedStatic<DBConnection> dbConnectionMock) {
-        EntityManager entityManagerMock = mock(EntityManager.class);
-        EntityTransaction entityTransaction = mock(EntityTransaction.class);
-        dbConnectionMock.when(DBConnection::getEntityManager).thenAnswer(new Answer() {
-            int count = 0;
+  @NotNull
+  static EntityManager mockEntityManager(MockedStatic<DBConnection> dbConnectionMock) {
+    EntityManager entityManagerMock = mock(EntityManager.class);
+    EntityTransaction entityTransaction = mock(EntityTransaction.class);
+    dbConnectionMock
+        .when(DBConnection::getEntityManager)
+        .thenAnswer(
+            new Answer() {
+              int count = 0;
 
-            @Override
-            public Object answer(InvocationOnMock invocation) {
+              @Override
+              public Object answer(InvocationOnMock invocation) {
                 System.out.println("returning entity manager #" + ++count);
                 return entityManagerMock;
-            }
+              }
+            });
+    when(entityManagerMock.getTransaction()).thenReturn(entityTransaction);
+    return entityManagerMock;
+  }
+
+  static void mockTupleQuery(EntityManager entityManagerMock) {
+    UserGroup userGroup = mock(UserGroup.class);
+    when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+    TypedQuery<Tuple> typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultStream())
+        .thenAnswer((Answer<Stream>) invocation -> getStream(userGroup));
+  }
+
+  @NotNull
+  static Stream<Tuple> getStream(UserGroup userGroup) {
+    return Stream.of(
+        new Tuple() {
+          @Override
+          public <X> X get(TupleElement<X> tupleElement) {
+            return null;
+          }
+
+          @Override
+          public <X> X get(String alias, Class<X> type) {
+            return null;
+          }
+
+          @Override
+          public Object get(String alias) {
+            if ("ug".equals(alias)) return userGroup;
+            if ("tSum".equals(alias)) return (double) 0;
+            return null;
+          }
+
+          @Override
+          public <X> X get(int i, Class<X> type) {
+            return null;
+          }
+
+          @Override
+          public Object get(int i) {
+            return null;
+          }
+
+          @Override
+          public Object[] toArray() {
+            return new Object[0];
+          }
+
+          @Override
+          public List<TupleElement<?>> getElements() {
+            return null;
+          }
         });
-        when(entityManagerMock.getTransaction()).thenReturn(entityTransaction);
-        return entityManagerMock;
-    }
+  }
 
-    static void mockTupleQuery(EntityManager entityManagerMock) {
-        UserGroup userGroup = mock(UserGroup.class);
-        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
-        TypedQuery<Tuple> typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultStream()).thenAnswer((Answer<Stream>) invocation -> getStream(userGroup));
-    }
-
-    @NotNull
-    static Stream<Tuple> getStream(UserGroup userGroup) {
-        return Stream.of(new Tuple() {
-            @Override
-            public <X> X get(TupleElement<X> tupleElement) {
-                return null;
-            }
-
-            @Override
-            public <X> X get(String alias, Class<X> type) {
-                return null;
-            }
-
-            @Override
-            public Object get(String alias) {
-                if ("ug".equals(alias)) return userGroup;
-                if ("tSum".equals(alias)) return (double) 0;
-                return null;
-            }
-
-            @Override
-            public <X> X get(int i, Class<X> type) {
-                return null;
-            }
-
-            @Override
-            public Object get(int i) {
-                return null;
-            }
-
-            @Override
-            public Object[] toArray() {
-                return new Object[0];
-            }
-
-            @Override
-            public List<TupleElement<?>> getElements() {
-                return null;
-            }
-        });
-    }
-
-    static void mockSettingValueQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(SettingValue.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
-    }
+  static void mockSettingValueQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(SettingValue.class)))
+        .thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/EntityManagerMockHelper.java
+++ b/src/test/java/kernbeisser/Reports/EntityManagerMockHelper.java
@@ -1,0 +1,94 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.SettingValue;
+import kernbeisser.DBEntities.UserGroup;
+import org.jetbrains.annotations.NotNull;
+import org.mockito.MockedStatic;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.persistence.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EntityManagerMockHelper {
+    @NotNull
+    static EntityManager mockEntityManager(MockedStatic<DBConnection> dbConnectionMock) {
+        EntityManager entityManagerMock = mock(EntityManager.class);
+        EntityTransaction entityTransaction = mock(EntityTransaction.class);
+        dbConnectionMock.when(DBConnection::getEntityManager).thenAnswer(new Answer() {
+            int count = 0;
+
+            @Override
+            public Object answer(InvocationOnMock invocation) {
+                System.out.println("returning entity manager #" + ++count);
+                return entityManagerMock;
+            }
+        });
+        when(entityManagerMock.getTransaction()).thenReturn(entityTransaction);
+        return entityManagerMock;
+    }
+
+    static void mockTupleQuery(EntityManager entityManagerMock) {
+        UserGroup userGroup = mock(UserGroup.class);
+        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+        TypedQuery<Tuple> typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Tuple.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultStream()).thenAnswer((Answer<Stream>) invocation -> getStream(userGroup));
+    }
+
+    @NotNull
+    static Stream<Tuple> getStream(UserGroup userGroup) {
+        return Stream.of(new Tuple() {
+            @Override
+            public <X> X get(TupleElement<X> tupleElement) {
+                return null;
+            }
+
+            @Override
+            public <X> X get(String alias, Class<X> type) {
+                return null;
+            }
+
+            @Override
+            public Object get(String alias) {
+                if ("ug".equals(alias)) return userGroup;
+                if ("tSum".equals(alias)) return (double) 0;
+                return null;
+            }
+
+            @Override
+            public <X> X get(int i, Class<X> type) {
+                return null;
+            }
+
+            @Override
+            public Object get(int i) {
+                return null;
+            }
+
+            @Override
+            public Object[] toArray() {
+                return new Object[0];
+            }
+
+            @Override
+            public List<TupleElement<?>> getElements() {
+                return null;
+            }
+        });
+    }
+
+    static void mockSettingValueQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(SettingValue.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InventoryCountingListsTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryCountingListsTest.java
@@ -1,0 +1,23 @@
+package kernbeisser.Reports;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class InventoryCountingListsTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new InventoryCountingLists(null, now);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Zähllisten_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InventoryCountingListsTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryCountingListsTest.java
@@ -1,23 +1,21 @@
 package kernbeisser.Reports;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 class InventoryCountingListsTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new InventoryCountingLists(null, now);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new InventoryCountingLists(null, now);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Zähllisten_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("Zähllisten_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InventoryShelfDetailsTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfDetailsTest.java
@@ -1,23 +1,21 @@
 package kernbeisser.Reports;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 class InventoryShelfDetailsTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new InventoryShelfDetails(null, now);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new InventoryShelfDetails(null, now);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Regaldetails_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("Regaldetails_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InventoryShelfDetailsTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfDetailsTest.java
@@ -1,0 +1,23 @@
+package kernbeisser.Reports;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class InventoryShelfDetailsTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new InventoryShelfDetails(null, now);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Regaldetails_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InventoryShelfOverviewTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfOverviewTest.java
@@ -1,23 +1,21 @@
 package kernbeisser.Reports;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 class InventoryShelfOverviewTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new InventoryShelfOverview(null, now);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new InventoryShelfOverview(null, now);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Regalübersicht_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("Regalübersicht_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InventoryShelfOverviewTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfOverviewTest.java
@@ -1,0 +1,23 @@
+package kernbeisser.Reports;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class InventoryShelfOverviewTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new InventoryShelfOverview(null, now);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Regalübersicht_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InventoryShelfStocksTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfStocksTest.java
@@ -1,23 +1,21 @@
 package kernbeisser.Reports;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 class InventoryShelfStocksTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new InventoryShelfStocks(null, now);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new InventoryShelfStocks(null, now);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("InventurRegalBestände_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("InventurRegalBestände_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InventoryShelfStocksTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryShelfStocksTest.java
@@ -1,0 +1,23 @@
+package kernbeisser.Reports;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class InventoryShelfStocksTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new InventoryShelfStocks(null, now);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("InventurRegalBestände_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InventoryStocksTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryStocksTest.java
@@ -1,23 +1,21 @@
 package kernbeisser.Reports;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.time.LocalDate;
-
 class InventoryStocksTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new InventoryStocks(now);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new InventoryStocks(now);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("InventurBestände_" + now, result);
-
-    }
+    // assert
+    Assertions.assertEquals("InventurBestände_" + now, result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InventoryStocksTest.java
+++ b/src/test/java/kernbeisser/Reports/InventoryStocksTest.java
@@ -1,0 +1,23 @@
+package kernbeisser.Reports;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+class InventoryStocksTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new InventoryStocks(now);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("InventurBestände_" + now, result);
+
+    }
+}

--- a/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
+++ b/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
@@ -1,5 +1,13 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.*;
 import kernbeisser.Exeptions.MissingFullMemberException;
@@ -9,76 +17,67 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 class InvoiceReportTest {
 
-    @Test
-    void createOutFileName() throws MissingFullMemberException {
-        // arrange
-        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
-        Purchase purchase = createPurchase(now);
-        Report report = new InvoiceReport(purchase);
+  @Test
+  void createOutFileName() throws MissingFullMemberException {
+    // arrange
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+    Purchase purchase = createPurchase(now);
+    Report report = new InvoiceReport(purchase);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("42_testVorname_testNachname_" + now, result);
+    // assert
+    Assertions.assertEquals("42_testVorname_testNachname_" + now, result);
+  }
 
+  @NotNull
+  private static Purchase createPurchase(Instant now) {
+    Purchase purchase = mock(Purchase.class);
+    SaleSession session = mock(SaleSession.class);
+    User user = mock(User.class);
+    when(user.getFirstName()).thenReturn("testVorname");
+    when(user.getSurname()).thenReturn("testNachname");
+    when(user.getUserGroup()).thenReturn(mock(UserGroup.class));
+    when(user.isFullMember()).thenReturn(true);
+    when(session.getCustomer()).thenReturn(user);
+    when(session.getSeller()).thenReturn(user);
+    when(purchase.getSession()).thenReturn(session);
+    when(purchase.getCreateDate()).thenReturn(now);
+    when(purchase.getId()).thenReturn(42L);
+    return purchase;
+  }
+
+  @Test
+  void lazyGetJspPrint() throws MissingFullMemberException {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+      Purchase purchase = createPurchase(now);
+
+      // act
+      Report report = new InvoiceReport(purchase);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.INVOICE_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @NotNull
-    private static Purchase createPurchase(Instant now) {
-        Purchase purchase = mock(Purchase.class);
-        SaleSession session = mock(SaleSession.class);
-        User user = mock(User.class);
-        when(user.getFirstName()).thenReturn("testVorname");
-        when(user.getSurname()).thenReturn("testNachname");
-        when(user.getUserGroup()).thenReturn(mock(UserGroup.class));
-        when(user.isFullMember()).thenReturn(true);
-        when(session.getCustomer()).thenReturn(user);
-        when(session.getSeller()).thenReturn(user);
-        when(purchase.getSession()).thenReturn(session);
-        when(purchase.getCreateDate()).thenReturn(now);
-        when(purchase.getId()).thenReturn(42L);
-        return purchase;
-    }
-
-    @Test
-    void lazyGetJspPrint() throws MissingFullMemberException {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
-
-            Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
-            Purchase purchase = createPurchase(now);
-
-            // act
-            Report report = new InvoiceReport(purchase);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.INVOICE_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    static void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
-    }
-
+  static void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class)))
+        .thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
+++ b/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
@@ -1,0 +1,84 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.*;
+import kernbeisser.Exeptions.MissingFullMemberException;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class InvoiceReportTest {
+
+    @Test
+    void createOutFileName() throws MissingFullMemberException {
+        // arrange
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Purchase purchase = createPurchase(now);
+        Report report = new InvoiceReport(purchase);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("42_testVorname_testNachname_" + now, result);
+
+    }
+
+    @NotNull
+    private static Purchase createPurchase(Instant now) {
+        Purchase purchase = mock(Purchase.class);
+        SaleSession session = mock(SaleSession.class);
+        User user = mock(User.class);
+        when(user.getFirstName()).thenReturn("testVorname");
+        when(user.getSurname()).thenReturn("testNachname");
+        when(user.getUserGroup()).thenReturn(mock(UserGroup.class));
+        when(user.isFullMember()).thenReturn(true);
+        when(session.getCustomer()).thenReturn(user);
+        when(session.getSeller()).thenReturn(user);
+        when(purchase.getSession()).thenReturn(session);
+        when(purchase.getCreateDate()).thenReturn(now);
+        when(purchase.getId()).thenReturn(42L);
+        return purchase;
+    }
+
+    @Test
+    void lazyGetJspPrint() throws MissingFullMemberException {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+            Purchase purchase = createPurchase(now);
+
+            // act
+            Report report = new InvoiceReport(purchase);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.INVOICE_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    static void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/KeyUserListTest.java
+++ b/src/test/java/kernbeisser/Reports/KeyUserListTest.java
@@ -1,0 +1,62 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.User;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class KeyUserListTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+        Report report = new KeyUserList(null);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Ladenbenutzerschlüssel_" + Timestamp.from(now), result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            // act
+            Report report = new KeyUserList(null);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            // FIXME
+            // Assertions.assertEquals(ReportFileNames.KEY_USER_LIST_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    private void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultStream()).thenReturn(Stream.empty());
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/KeyUserListTest.java
+++ b/src/test/java/kernbeisser/Reports/KeyUserListTest.java
@@ -1,5 +1,14 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.User;
 import net.sf.jasperreports.engine.JasperPrint;
@@ -7,56 +16,46 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.stream.Stream;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 class KeyUserListTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
-        Report report = new KeyUserList(null);
+  @Test
+  void createOutFileName() {
+    // arrange
+    Instant now = Instant.now().truncatedTo(ChronoUnit.MINUTES);
+    Report report = new KeyUserList(null);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Ladenbenutzerschlüssel_" + Timestamp.from(now), result);
+    // assert
+    Assertions.assertEquals("Ladenbenutzerschlüssel_" + Timestamp.from(now), result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      // act
+      Report report = new KeyUserList(null);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      // FIXME
+      // Assertions.assertEquals(ReportFileNames.KEY_USER_LIST_REPORT_FILENAME, jspPrint.getName() +
+      // ".jrxml");
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
-
-            // act
-            Report report = new KeyUserList(null);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            // FIXME
-            // Assertions.assertEquals(ReportFileNames.KEY_USER_LIST_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    private void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultStream()).thenReturn(Stream.empty());
-    }
-
+  private void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(User.class))).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultStream()).thenReturn(Stream.empty());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/LoginInfoTest.java
+++ b/src/test/java/kernbeisser/Reports/LoginInfoTest.java
@@ -1,0 +1,51 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.User;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+
+import static org.mockito.Mockito.mockStatic;
+
+class LoginInfoTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        User user = new User();
+        user.setUsername("testaccount");
+        Report report = new LoginInfo(user, null);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("loginInfo_" + "testaccount", result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+
+            User user = new User();
+            user.setUsername("testaccount");
+
+            // act
+            Report report = new LoginInfo(user, null);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals("AnmeldeInformation", jspPrint.getName());
+        }
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/LoginInfoTest.java
+++ b/src/test/java/kernbeisser/Reports/LoginInfoTest.java
@@ -1,5 +1,8 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.mockStatic;
+
+import javax.persistence.EntityManager;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.User;
 import net.sf.jasperreports.engine.JasperPrint;
@@ -7,45 +10,40 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-
-import static org.mockito.Mockito.mockStatic;
-
 class LoginInfoTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        User user = new User();
-        user.setUsername("testaccount");
-        Report report = new LoginInfo(user, null);
+  @Test
+  void createOutFileName() {
+    // arrange
+    User user = new User();
+    user.setUsername("testaccount");
+    Report report = new LoginInfo(user, null);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("loginInfo_" + "testaccount", result);
+    // assert
+    Assertions.assertEquals("loginInfo_" + "testaccount", result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+
+      User user = new User();
+      user.setUsername("testaccount");
+
+      // act
+      Report report = new LoginInfo(user, null);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals("AnmeldeInformation", jspPrint.getName());
     }
-
-    @Test
-    void lazyGetJspPrint() {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-
-            User user = new User();
-            user.setUsername("testaccount");
-
-            // act
-            Report report = new LoginInfo(user, null);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals("AnmeldeInformation", jspPrint.getName());
-        }
-    }
-
+  }
 }

--- a/src/test/java/kernbeisser/Reports/PermissionHoldersTest.java
+++ b/src/test/java/kernbeisser/Reports/PermissionHoldersTest.java
@@ -1,5 +1,11 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.Permission;
 import net.sf.jasperreports.engine.JasperPrint;
@@ -7,53 +13,46 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.LocalDate;
-import java.util.Collections;
-
-import static org.mockito.Mockito.*;
-
 class PermissionHoldersTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new PermissionHolders(true);
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new PermissionHolders(true);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("RollenInhaber" + now, result);
+    // assert
+    Assertions.assertEquals("RollenInhaber" + now, result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      // act
+      Report report = new PermissionHolders(true);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
-
-            // act
-            Report report = new PermissionHolders(true);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    static void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Permission.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
-    }
-
-
+  static void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Permission.class)))
+        .thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/PermissionHoldersTest.java
+++ b/src/test/java/kernbeisser/Reports/PermissionHoldersTest.java
@@ -1,0 +1,59 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Permission;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+class PermissionHoldersTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new PermissionHolders(true);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("RollenInhaber" + now, result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            // act
+            Report report = new PermissionHolders(true);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    static void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Permission.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+    }
+
+
+}

--- a/src/test/java/kernbeisser/Reports/PreOrderChecklistTest.java
+++ b/src/test/java/kernbeisser/Reports/PreOrderChecklistTest.java
@@ -1,49 +1,48 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.mockStatic;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import javax.persistence.EntityManager;
 import kernbeisser.DBConnection.DBConnection;
 import net.sf.jasperreports.engine.JasperPrint;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import java.time.LocalDate;
-import java.util.Collections;
-
-import static org.mockito.Mockito.mockStatic;
-
 class PreOrderChecklistTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        LocalDate now = LocalDate.now();
-        Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
+  @Test
+  void createOutFileName() {
+    // arrange
+    LocalDate now = LocalDate.now();
+    Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("preOrderChecklist" + now, result);
+    // assert
+    Assertions.assertEquals("preOrderChecklist" + now, result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+
+      // act
+      Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.PREORDER_CHECKLIST_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
-
-    @Test
-    void lazyGetJspPrint() {
-
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-
-            // act
-            Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.PREORDER_CHECKLIST_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
+  }
 }

--- a/src/test/java/kernbeisser/Reports/PreOrderChecklistTest.java
+++ b/src/test/java/kernbeisser/Reports/PreOrderChecklistTest.java
@@ -1,0 +1,49 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mockStatic;
+
+class PreOrderChecklistTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        LocalDate now = LocalDate.now();
+        Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("preOrderChecklist" + now, result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+
+            // act
+            Report report = new PreOrderChecklist(LocalDate.MIN, Collections.emptyList());
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.PREORDER_CHECKLIST_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/PriceListReportTest.java
+++ b/src/test/java/kernbeisser/Reports/PriceListReportTest.java
@@ -1,0 +1,42 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBEntities.PriceList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+@ExtendWith(MockitoExtension.class)
+class PriceListReportTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        Report report = new PriceListReport(Collections.emptyList(), "testName");
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Preisliste testName", result);
+    }
+
+    @Test
+    void createOutFileNamePriceList() {
+        // arrange
+        PriceList priceList = Mockito.mock(PriceList.class);
+        Mockito.when(priceList.getAllArticles()).thenReturn(Collections.emptyList());
+        Mockito.when(priceList.getName()).thenReturn("testName");
+
+        Report report = new PriceListReport(priceList);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Preisliste testName", result);
+    }
+}

--- a/src/test/java/kernbeisser/Reports/PriceListReportTest.java
+++ b/src/test/java/kernbeisser/Reports/PriceListReportTest.java
@@ -1,5 +1,6 @@
 package kernbeisser.Reports;
 
+import java.util.Collections;
 import kernbeisser.DBEntities.PriceList;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -7,36 +8,34 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Collections;
-
 @ExtendWith(MockitoExtension.class)
 class PriceListReportTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        Report report = new PriceListReport(Collections.emptyList(), "testName");
+  @Test
+  void createOutFileName() {
+    // arrange
+    Report report = new PriceListReport(Collections.emptyList(), "testName");
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Preisliste testName", result);
-    }
+    // assert
+    Assertions.assertEquals("Preisliste testName", result);
+  }
 
-    @Test
-    void createOutFileNamePriceList() {
-        // arrange
-        PriceList priceList = Mockito.mock(PriceList.class);
-        Mockito.when(priceList.getAllArticles()).thenReturn(Collections.emptyList());
-        Mockito.when(priceList.getName()).thenReturn("testName");
+  @Test
+  void createOutFileNamePriceList() {
+    // arrange
+    PriceList priceList = Mockito.mock(PriceList.class);
+    Mockito.when(priceList.getAllArticles()).thenReturn(Collections.emptyList());
+    Mockito.when(priceList.getName()).thenReturn("testName");
 
-        Report report = new PriceListReport(priceList);
+    Report report = new PriceListReport(priceList);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Preisliste testName", result);
-    }
+    // assert
+    Assertions.assertEquals("Preisliste testName", result);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/TillrollReportTest.java
+++ b/src/test/java/kernbeisser/Reports/TillrollReportTest.java
@@ -1,5 +1,11 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.ShoppingItem;
 import net.sf.jasperreports.engine.JasperPrint;
@@ -7,58 +13,53 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.util.Collections;
-
-import static org.mockito.Mockito.*;
-
 class TillrollReportTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
-        Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
-        Report report = new TillrollReport(start, end);
+  @Test
+  void createOutFileName() {
+    // arrange
+    Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
+    Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
+    Report report = new TillrollReport(start, end);
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        String expected = "KernbeisserBonrolle_" + "2001-01-01 11:15:30.0" + "_" + "2525-12-31 11:15:30.0";
-        Assertions.assertEquals(expected, result);
+    // assert
+    String expected =
+        "KernbeisserBonrolle_" + "2001-01-01 11:15:30.0" + "_" + "2525-12-31 11:15:30.0";
+    Assertions.assertEquals(expected, result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
+      Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
+
+      // act
+      Report report = new TillrollReport(start, end);
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.TILLROLL_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
-
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
-
-            Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
-            Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
-
-            // act
-            Report report = new TillrollReport(start, end);
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.TILLROLL_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    static void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
-    }
-
+  static void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class)))
+        .thenReturn(typedQueryTuple);
+    when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/TillrollReportTest.java
+++ b/src/test/java/kernbeisser/Reports/TillrollReportTest.java
@@ -1,0 +1,64 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.ShoppingItem;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+class TillrollReportTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
+        Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
+        Report report = new TillrollReport(start, end);
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        String expected = "KernbeisserBonrolle_" + "2001-01-01 11:15:30.0" + "_" + "2525-12-31 11:15:30.0";
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            Instant end = Instant.parse("2525-12-31T10:15:30.00Z");
+            Instant start = Instant.parse("2001-01-01T10:15:30.00Z");
+
+            // act
+            Report report = new TillrollReport(start, end);
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.TILLROLL_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    static void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(ShoppingItem.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.setParameter(anyString(), any())).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/TransactionStatementTest.java
+++ b/src/test/java/kernbeisser/Reports/TransactionStatementTest.java
@@ -1,0 +1,88 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.Transaction;
+import kernbeisser.DBEntities.User;
+import kernbeisser.DBEntities.UserGroup;
+import kernbeisser.Enums.StatementType;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class TransactionStatementTest {
+
+    @Test
+    void createOutFileName() {
+        // arrange
+        User user = Mockito.mock(User.class);
+        UserGroup userGroup = Mockito.mock(UserGroup.class);
+        Mockito.when(user.getUserGroup()).thenReturn(userGroup);
+        Mockito.when(userGroup.getId()).thenReturn(42);
+        Mockito.when(user.toString()).thenReturn("testuser");
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            mockQuery(entityManagerMock, new Transaction());
+
+            Report report = new TransactionStatement(user, StatementType.FULL, true);
+
+            // act
+            String result = report.createOutFileName();
+
+            // assert
+            String expected = "Kontoauszug_" + "testuser";
+            Assertions.assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+        User user = Mockito.mock(User.class);
+        UserGroup userGroup = Mockito.mock(UserGroup.class);
+        Mockito.when(user.getUserGroup()).thenReturn(userGroup);
+        Mockito.when(userGroup.getId()).thenReturn(42);
+        Mockito.when(user.toString()).thenReturn("testuser");
+
+        Transaction transaction = mock(Transaction.class);
+        when(transaction.getDate()).thenReturn(Instant.now());
+        when(transaction.getFromUserGroup()).thenReturn(userGroup);
+
+        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock, transaction);
+
+            Report report = new TransactionStatement(user, StatementType.FULL, true);
+
+            // act
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.TRANSACTION_STATEMENT_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    private static void mockQuery(EntityManager entityManagerMock, @NotNull Transaction transaction) {
+        TypedQuery<Transaction> typedQueryPurchase = Mockito.mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Transaction.class))).thenReturn(typedQueryPurchase);
+        when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
+        when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(transaction));
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/TransactionStatementTest.java
+++ b/src/test/java/kernbeisser/Reports/TransactionStatementTest.java
@@ -1,5 +1,12 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.Transaction;
 import kernbeisser.DBEntities.User;
@@ -12,77 +19,70 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-
 class TransactionStatementTest {
 
-    @Test
-    void createOutFileName() {
-        // arrange
-        User user = Mockito.mock(User.class);
-        UserGroup userGroup = Mockito.mock(UserGroup.class);
-        Mockito.when(user.getUserGroup()).thenReturn(userGroup);
-        Mockito.when(userGroup.getId()).thenReturn(42);
-        Mockito.when(user.toString()).thenReturn("testuser");
+  @Test
+  void createOutFileName() {
+    // arrange
+    User user = Mockito.mock(User.class);
+    UserGroup userGroup = Mockito.mock(UserGroup.class);
+    Mockito.when(user.getUserGroup()).thenReturn(userGroup);
+    Mockito.when(userGroup.getId()).thenReturn(42);
+    Mockito.when(user.toString()).thenReturn("testuser");
 
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            mockQuery(entityManagerMock, new Transaction());
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      mockQuery(entityManagerMock, new Transaction());
 
-            Report report = new TransactionStatement(user, StatementType.FULL, true);
+      Report report = new TransactionStatement(user, StatementType.FULL, true);
 
-            // act
-            String result = report.createOutFileName();
+      // act
+      String result = report.createOutFileName();
 
-            // assert
-            String expected = "Kontoauszug_" + "testuser";
-            Assertions.assertEquals(expected, result);
-        }
+      // assert
+      String expected = "Kontoauszug_" + "testuser";
+      Assertions.assertEquals(expected, result);
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
-        User user = Mockito.mock(User.class);
-        UserGroup userGroup = Mockito.mock(UserGroup.class);
-        Mockito.when(user.getUserGroup()).thenReturn(userGroup);
-        Mockito.when(userGroup.getId()).thenReturn(42);
-        Mockito.when(user.toString()).thenReturn("testuser");
+  @Test
+  void lazyGetJspPrint() {
+    User user = Mockito.mock(User.class);
+    UserGroup userGroup = Mockito.mock(UserGroup.class);
+    Mockito.when(user.getUserGroup()).thenReturn(userGroup);
+    Mockito.when(userGroup.getId()).thenReturn(42);
+    Mockito.when(user.toString()).thenReturn("testuser");
 
-        Transaction transaction = mock(Transaction.class);
-        when(transaction.getDate()).thenReturn(Instant.now());
-        when(transaction.getFromUserGroup()).thenReturn(userGroup);
+    Transaction transaction = mock(Transaction.class);
+    when(transaction.getDate()).thenReturn(Instant.now());
+    when(transaction.getFromUserGroup()).thenReturn(userGroup);
 
-        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock, transaction);
+    when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock, transaction);
 
-            Report report = new TransactionStatement(user, StatementType.FULL, true);
+      Report report = new TransactionStatement(user, StatementType.FULL, true);
 
-            // act
-            JasperPrint jspPrint = report.lazyGetJspPrint();
+      // act
+      JasperPrint jspPrint = report.lazyGetJspPrint();
 
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.TRANSACTION_STATEMENT_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.TRANSACTION_STATEMENT_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    private static void mockQuery(EntityManager entityManagerMock, @NotNull Transaction transaction) {
-        TypedQuery<Transaction> typedQueryPurchase = Mockito.mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Transaction.class))).thenReturn(typedQueryPurchase);
-        when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
-        when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(transaction));
-    }
-
+  private static void mockQuery(EntityManager entityManagerMock, @NotNull Transaction transaction) {
+    TypedQuery<Transaction> typedQueryPurchase = Mockito.mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Transaction.class)))
+        .thenReturn(typedQueryPurchase);
+    when(typedQueryPurchase.setParameter(anyString(), any())).thenReturn(typedQueryPurchase);
+    when(typedQueryPurchase.getResultList()).thenReturn(Collections.singletonList(transaction));
+  }
 }

--- a/src/test/java/kernbeisser/Reports/TrialMemberReportTest.java
+++ b/src/test/java/kernbeisser/Reports/TrialMemberReportTest.java
@@ -1,5 +1,11 @@
 package kernbeisser.Reports;
 
+import static org.mockito.Mockito.*;
+
+import java.time.Instant;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.Reports.ReportDTO.TrialMemberReportEntry;
 import kernbeisser.Useful.Date;
@@ -8,51 +14,45 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.time.Instant;
-import java.util.Collections;
-
-import static org.mockito.Mockito.*;
-
 class TrialMemberReportTest {
-    @Test
-    void createOutFileName() {
-        // arrange
-        Instant now = Instant.now();
-        Report report = new TrialMemberReport();
+  @Test
+  void createOutFileName() {
+    // arrange
+    Instant now = Instant.now();
+    Report report = new TrialMemberReport();
 
-        // act
-        String result = report.createOutFileName();
+    // act
+    String result = report.createOutFileName();
 
-        // assert
-        Assertions.assertEquals("Probemitlieder_" + Date.INSTANT_DATE.format(now), result);
+    // assert
+    Assertions.assertEquals("Probemitlieder_" + Date.INSTANT_DATE.format(now), result);
+  }
+
+  @Test
+  void lazyGetJspPrint() {
+
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+      mockQuery(entityManagerMock);
+
+      // act
+      Report report = new TrialMemberReport();
+      JasperPrint jspPrint = report.lazyGetJspPrint();
+
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      Assertions.assertEquals(
+          ReportFileNames.TRIAL_MEMBER_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
-
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
-            mockQuery(entityManagerMock);
-
-            // act
-            Report report = new TrialMemberReport();
-            JasperPrint jspPrint = report.lazyGetJspPrint();
-
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            Assertions.assertEquals(ReportFileNames.TRIAL_MEMBER_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
-    }
-
-    static void mockQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQueryTuple = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(TrialMemberReportEntry.class))).thenReturn(typedQueryTuple);
-        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
-    }
-
+  static void mockQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQueryTuple = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(TrialMemberReportEntry.class)))
+        .thenReturn(typedQueryTuple);
+    when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+  }
 }

--- a/src/test/java/kernbeisser/Reports/TrialMemberReportTest.java
+++ b/src/test/java/kernbeisser/Reports/TrialMemberReportTest.java
@@ -1,0 +1,58 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.Reports.ReportDTO.TrialMemberReportEntry;
+import kernbeisser.Useful.Date;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.time.Instant;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+class TrialMemberReportTest {
+    @Test
+    void createOutFileName() {
+        // arrange
+        Instant now = Instant.now();
+        Report report = new TrialMemberReport();
+
+        // act
+        String result = report.createOutFileName();
+
+        // assert
+        Assertions.assertEquals("Probemitlieder_" + Date.INSTANT_DATE.format(now), result);
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+            mockQuery(entityManagerMock);
+
+            // act
+            Report report = new TrialMemberReport();
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            Assertions.assertEquals(ReportFileNames.TRIAL_MEMBER_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    static void mockQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQueryTuple = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(TrialMemberReportEntry.class))).thenReturn(typedQueryTuple);
+        when(typedQueryTuple.getResultList()).thenReturn(Collections.emptyList());
+    }
+
+}

--- a/src/test/java/kernbeisser/Reports/UserBalanceReportTest.java
+++ b/src/test/java/kernbeisser/Reports/UserBalanceReportTest.java
@@ -1,5 +1,15 @@
 package kernbeisser.Reports;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.UserGroup;
 import net.sf.jasperreports.engine.JasperPrint;
@@ -9,99 +19,91 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import javax.persistence.EntityManager;
-import javax.persistence.TypedQuery;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Collections;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
-
 class UserBalanceReportTest {
 
-    @Test
-    void createOutFileName_default() {
-        UserGroup userGroup = mock(UserGroup.class);
-        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            mockUserGroupQuery(entityManagerMock, userGroup);
+  @Test
+  void createOutFileName_default() {
+    UserGroup userGroup = mock(UserGroup.class);
+    when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      mockUserGroupQuery(entityManagerMock, userGroup);
 
-            Report report = new UserBalanceReport(-1L, true);
+      Report report = new UserBalanceReport(-1L, true);
 
-            // act
-            String result = report.createOutFileName();
+      // act
+      String result = report.createOutFileName();
 
-            // assert
-            String expected = "KernbeisserGuthabenstände_" + Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES));
-            Assertions.assertEquals(expected, result);
-        }
+      // assert
+      String expected =
+          "KernbeisserGuthabenstände_"
+              + Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES));
+      Assertions.assertEquals(expected, result);
     }
+  }
 
-    @Test
-    void createOutFileName_reportNo() {
-        UserGroup userGroup = mock(UserGroup.class);
-        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+  @Test
+  void createOutFileName_reportNo() {
+    UserGroup userGroup = mock(UserGroup.class);
+    when(userGroup.getMembers()).thenReturn(Collections.emptyList());
 
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            mockUserGroupQuery(entityManagerMock, userGroup);
-            mockLongQuery(entityManagerMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      mockUserGroupQuery(entityManagerMock, userGroup);
+      mockLongQuery(entityManagerMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
 
-            Report report = new UserBalanceReport(42L, true);
+      Report report = new UserBalanceReport(42L, true);
 
-            // act
-            String result = report.createOutFileName();
+      // act
+      String result = report.createOutFileName();
 
-            // assert
-            String expected = "KernbeisserGuthabenstände_42";
-            Assertions.assertEquals(expected, result);
-        }
+      // assert
+      String expected = "KernbeisserGuthabenstände_42";
+      Assertions.assertEquals(expected, result);
     }
+  }
 
-    @Test
-    void lazyGetJspPrint() {
+  @Test
+  void lazyGetJspPrint() {
 
-        UserGroup userGroup = mock(UserGroup.class);
-        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
-        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
-            // arrange
-            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
-            mockUserGroupQuery(entityManagerMock, userGroup);
-            mockLongQuery(entityManagerMock);
-            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
-            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+    UserGroup userGroup = mock(UserGroup.class);
+    when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+    try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+      // arrange
+      EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+      mockUserGroupQuery(entityManagerMock, userGroup);
+      mockLongQuery(entityManagerMock);
+      EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+      EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
 
-            Report report = new UserBalanceReport(42L, true);
+      Report report = new UserBalanceReport(42L, true);
 
-            // act
-            JasperPrint jspPrint = report.lazyGetJspPrint();
+      // act
+      JasperPrint jspPrint = report.lazyGetJspPrint();
 
-            // assert
-            Assertions.assertNotNull(jspPrint);
-            // FIXME
-            //  Assertions.assertEquals(ReportFileNames.USER_BALANCE_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
-        }
+      // assert
+      Assertions.assertNotNull(jspPrint);
+      // FIXME
+      //  Assertions.assertEquals(ReportFileNames.USER_BALANCE_REPORT_FILENAME, jspPrint.getName() +
+      // ".jrxml");
     }
+  }
 
-    private static void mockUserGroupQuery(EntityManager entityManagerMock, @NotNull UserGroup userGroup) {
-        TypedQuery<UserGroup> typedQueryUserGroup = Mockito.mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(UserGroup.class))).thenReturn(typedQueryUserGroup);
-        when(typedQueryUserGroup.getResultList()).thenReturn(Collections.singletonList(userGroup));
-    }
+  private static void mockUserGroupQuery(
+      EntityManager entityManagerMock, @NotNull UserGroup userGroup) {
+    TypedQuery<UserGroup> typedQueryUserGroup = Mockito.mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(UserGroup.class)))
+        .thenReturn(typedQueryUserGroup);
+    when(typedQueryUserGroup.getResultList()).thenReturn(Collections.singletonList(userGroup));
+  }
 
-    private static void mockLongQuery(EntityManager entityManagerMock) {
-        TypedQuery typedQuery = mock(TypedQuery.class);
-        when(entityManagerMock.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
-        when(typedQuery.setParameter(anyString(), any())).thenReturn(typedQuery);
-        when(typedQuery.getSingleResult()).thenReturn(42L);
-    }
-
-
+  private static void mockLongQuery(EntityManager entityManagerMock) {
+    TypedQuery typedQuery = mock(TypedQuery.class);
+    when(entityManagerMock.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
+    when(typedQuery.setParameter(anyString(), any())).thenReturn(typedQuery);
+    when(typedQuery.getSingleResult()).thenReturn(42L);
+  }
 }

--- a/src/test/java/kernbeisser/Reports/UserBalanceReportTest.java
+++ b/src/test/java/kernbeisser/Reports/UserBalanceReportTest.java
@@ -1,0 +1,107 @@
+package kernbeisser.Reports;
+
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.DBEntities.UserGroup;
+import net.sf.jasperreports.engine.JasperPrint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class UserBalanceReportTest {
+
+    @Test
+    void createOutFileName_default() {
+        UserGroup userGroup = mock(UserGroup.class);
+        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            mockUserGroupQuery(entityManagerMock, userGroup);
+
+            Report report = new UserBalanceReport(-1L, true);
+
+            // act
+            String result = report.createOutFileName();
+
+            // assert
+            String expected = "KernbeisserGuthabenstände_" + Timestamp.from(Instant.now().truncatedTo(ChronoUnit.MINUTES));
+            Assertions.assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    void createOutFileName_reportNo() {
+        UserGroup userGroup = mock(UserGroup.class);
+        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            mockUserGroupQuery(entityManagerMock, userGroup);
+            mockLongQuery(entityManagerMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+
+            Report report = new UserBalanceReport(42L, true);
+
+            // act
+            String result = report.createOutFileName();
+
+            // assert
+            String expected = "KernbeisserGuthabenstände_42";
+            Assertions.assertEquals(expected, result);
+        }
+    }
+
+    @Test
+    void lazyGetJspPrint() {
+
+        UserGroup userGroup = mock(UserGroup.class);
+        when(userGroup.getMembers()).thenReturn(Collections.emptyList());
+        try (MockedStatic<DBConnection> dbConnectionMock = mockStatic(DBConnection.class)) {
+            // arrange
+            EntityManager entityManagerMock = EntityManagerMockHelper.mockEntityManager(dbConnectionMock);
+            mockUserGroupQuery(entityManagerMock, userGroup);
+            mockLongQuery(entityManagerMock);
+            EntityManagerMockHelper.mockTupleQuery(entityManagerMock);
+            EntityManagerMockHelper.mockSettingValueQuery(entityManagerMock);
+
+            Report report = new UserBalanceReport(42L, true);
+
+            // act
+            JasperPrint jspPrint = report.lazyGetJspPrint();
+
+            // assert
+            Assertions.assertNotNull(jspPrint);
+            // FIXME
+            //  Assertions.assertEquals(ReportFileNames.USER_BALANCE_REPORT_FILENAME, jspPrint.getName() + ".jrxml");
+        }
+    }
+
+    private static void mockUserGroupQuery(EntityManager entityManagerMock, @NotNull UserGroup userGroup) {
+        TypedQuery<UserGroup> typedQueryUserGroup = Mockito.mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(UserGroup.class))).thenReturn(typedQueryUserGroup);
+        when(typedQueryUserGroup.getResultList()).thenReturn(Collections.singletonList(userGroup));
+    }
+
+    private static void mockLongQuery(EntityManager entityManagerMock) {
+        TypedQuery typedQuery = mock(TypedQuery.class);
+        when(entityManagerMock.createQuery(anyString(), eq(Long.class))).thenReturn(typedQuery);
+        when(typedQuery.setParameter(anyString(), any())).thenReturn(typedQuery);
+        when(typedQuery.getSingleResult()).thenReturn(42L);
+    }
+
+
+}


### PR DESCRIPTION
Template file name wird aus Konstanten-Klasse gelesen.
Setzt natürlich voraus, dass alle Reports im richtigen Verzeichnis liegen (das selbe wie bisher).

Testabdeckung auf den Inventory*-Reports fehlt noch