### PR TITLE
768 remove entity ids from logic

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,11 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
     id("io.freefair.lombok") version "8.6"
 }
+spotless {
+    java {
+        toggleOffOn()
+    }
+}
 
 group 'Kernbeisser'
 version '2.0'

--- a/app/src/main/java/kernbeisser/DBEntities/ArticlePrintPool.java
+++ b/app/src/main/java/kernbeisser/DBEntities/ArticlePrintPool.java
@@ -52,7 +52,8 @@ public class ArticlePrintPool {
   }
 
   private static void deleteAll(EntityManager em) {
-    em.createQuery("delete from ArticlePrintPool").executeUpdate();
+    em.createQuery(em.getCriteriaBuilder().createCriteriaDelete(ArticlePrintPool.class))
+        .executeUpdate();
   }
 
   public static void clear() {

--- a/app/src/main/java/kernbeisser/DBEntities/CatalogEntry.java
+++ b/app/src/main/java/kernbeisser/DBEntities/CatalogEntry.java
@@ -252,7 +252,8 @@ public class CatalogEntry implements ActuallyCloneable {
     @Cleanup(value = "commit")
     EntityTransaction et = em.getTransaction();
     et.begin();
-    em.createQuery("DELETE FROM CatalogEntry").executeUpdate();
+    em.createQuery(em.getCriteriaBuilder().createCriteriaDelete(CatalogEntry.class))
+        .executeUpdate();
   }
 
   public boolean matches(String s) {

--- a/app/src/main/java/kernbeisser/DBEntities/Purchase.java
+++ b/app/src/main/java/kernbeisser/DBEntities/Purchase.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import rs.groump.Key;
 import rs.groump.PermissionKey;
 
-@Table
+@Table(uniqueConstraints = {@UniqueConstraint(name = "UX_purchase_bonNo", columnNames = "bonNo")})
 @Entity
 @EqualsAndHashCode(doNotUseGetters = true)
 public class Purchase implements UserRelated {
@@ -26,6 +26,11 @@ public class Purchase implements UserRelated {
   @Getter(onMethod_ = {@Key(PermissionKey.PURCHASE_ID_READ)})
   @Setter(onMethod_ = {@Key(PermissionKey.PURCHASE_ID_WRITE)})
   private long id;
+
+  @Column
+  @Getter(onMethod_ = {@Key(PermissionKey.PURCHASE_ID_READ)})
+  @Setter(onMethod_ = {@Key(PermissionKey.PURCHASE_ID_WRITE)})
+  private long bonNo;
 
   @ManyToOne
   @JoinColumn(nullable = false)

--- a/app/src/main/java/kernbeisser/DBEntities/Transaction.java
+++ b/app/src/main/java/kernbeisser/DBEntities/Transaction.java
@@ -34,8 +34,9 @@ import rs.groump.AccessManager;
 import rs.groump.Key;
 import rs.groump.PermissionKey;
 
-@Table(uniqueConstraints = {@UniqueConstraint(name = "UX_transaction_seqNo", columnNames = "seqNo")},
-        indexes = {@Index(name = "IX_transaction_date", columnList = "date")})
+@Table(
+    uniqueConstraints = {@UniqueConstraint(name = "UX_transaction_seqNo", columnNames = "seqNo")},
+    indexes = {@Index(name = "IX_transaction_date", columnList = "date")})
 @Entity
 @EqualsAndHashCode(doNotUseGetters = true)
 public class Transaction implements UserRelated {
@@ -47,7 +48,7 @@ public class Transaction implements UserRelated {
   @Setter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_WRITE)})
   private long id;
 
-  //introduced with hibernate 6 to ensure strict temporal sequence,
+  // introduced with hibernate 6 to ensure strict temporal sequence,
   // because with the new auto-increment models gaps in id order may be reused
   @Column
   @Getter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_READ)})
@@ -223,8 +224,8 @@ public class Transaction implements UserRelated {
       UserGroup fromUG,
       UserGroup toUG) {
     LogInModel.checkRefreshRequirements(fromUG, toUG);
-    long lastSeqNo = QueryBuilder
-            .select(Transaction_.seqNo)
+    long lastSeqNo =
+        QueryBuilder.select(Transaction_.seqNo)
             .orderBy(Transaction_.seqNo.desc())
             .limit(1)
             .getSingleResultOptional()

--- a/app/src/main/java/kernbeisser/DBEntities/Transaction.java
+++ b/app/src/main/java/kernbeisser/DBEntities/Transaction.java
@@ -34,7 +34,8 @@ import rs.groump.AccessManager;
 import rs.groump.Key;
 import rs.groump.PermissionKey;
 
-@Table(indexes = {@Index(name = "IX_transaction_date", columnList = "date")})
+@Table(uniqueConstraints = {@UniqueConstraint(name = "UX_transaction_seqNo", columnNames = "seqNo")},
+        indexes = {@Index(name = "IX_transaction_date", columnList = "date")})
 @Entity
 @EqualsAndHashCode(doNotUseGetters = true)
 public class Transaction implements UserRelated {
@@ -45,6 +46,13 @@ public class Transaction implements UserRelated {
   @Getter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_READ)})
   @Setter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_WRITE)})
   private long id;
+
+  //introduced with hibernate 6 to ensure strict temporal sequence,
+  // because with the new auto-increment models gaps in id order may be reused
+  @Column
+  @Getter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_READ)})
+  @Setter(onMethod_ = {@Key(PermissionKey.TRANSACTION_ID_WRITE)})
+  private long seqNo;
 
   @Column
   @Getter(onMethod_ = {@Key(PermissionKey.TRANSACTION_VALUE_READ)})
@@ -215,7 +223,14 @@ public class Transaction implements UserRelated {
       UserGroup fromUG,
       UserGroup toUG) {
     LogInModel.checkRefreshRequirements(fromUG, toUG);
+    long lastSeqNo = QueryBuilder
+            .select(Transaction_.seqNo)
+            .orderBy(Transaction_.seqNo.desc())
+            .limit(1)
+            .getSingleResultOptional()
+            .orElse(0L);
     Transaction transaction = new Transaction();
+    transaction.seqNo = lastSeqNo + 1;
     transaction.value = value;
     transaction.toUser = to;
     transaction.fromUser = from;
@@ -300,7 +315,7 @@ public class Transaction implements UserRelated {
     List<Transaction> transactions =
         QueryBuilder.selectAll(Transaction.class)
             .where(Transaction_.accountingReportNo.eq(reportNo))
-            .orderBy(Transaction_.id.asc())
+            .orderBy(Transaction_.seqNo.asc())
             .getResultList();
     if (transactions.isEmpty()) {
       throw new NoTransactionsFoundException();
@@ -315,7 +330,7 @@ public class Transaction implements UserRelated {
             .where(
                 Transaction_.accountingReportNo.isNull(),
                 or(Transaction_.fromUser.eq(kbUser), Transaction_.toUser.eq(kbUser)))
-            .orderBy(Transaction_.id.asc())
+            .orderBy(Transaction_.seqNo.asc())
             .getResultList();
     if (transactions.isEmpty()) {
       throw new NoTransactionsFoundException();

--- a/app/src/main/java/kernbeisser/Reports/InvoiceReport.java
+++ b/app/src/main/java/kernbeisser/Reports/InvoiceReport.java
@@ -23,7 +23,7 @@ public class InvoiceReport extends Report {
   String createOutFileName() {
     return String.format(
         "%d_%s_%s_%s",
-        purchase.getId(),
+        purchase.getBonNo(),
         purchase.getSession().getCustomer().getFirstName(),
         purchase.getSession().getCustomer().getSurname(),
         purchase.getCreateDate().toString());
@@ -49,7 +49,7 @@ public class InvoiceReport extends Report {
       credit = purchase.getSession().getCustomer().valueAt(at) - purchase.getSum();
     }
     Map<String, Object> reportParams = new HashMap<>();
-    reportParams.put("BonNo", purchase.getId());
+    reportParams.put("BonNo", purchase.getBonNo());
     reportParams.put("Customer", purchase.getSession().getCustomer().getFullName());
     reportParams.put("Seller", purchase.getSession().getSeller().getFullName());
     reportParams.put("Credit", credit);

--- a/app/src/main/java/kernbeisser/Reports/PermissionHolders.java
+++ b/app/src/main/java/kernbeisser/Reports/PermissionHolders.java
@@ -1,25 +1,26 @@
 package kernbeisser.Reports;
 
 import java.time.LocalDate;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import kernbeisser.DBConnection.DBConnection;
 import kernbeisser.DBEntities.Permission;
+import kernbeisser.DBEntities.Permission_;
 
 public class PermissionHolders extends Report {
   private final Collection<Permission> permissions;
 
   public PermissionHolders(boolean withKeys) {
     super(ReportFileNames.PERMISSION_HOLDERS_REPORT_FILENAME);
+    List<String> excludedPermissionNames =
+        new ArrayList<>(Arrays.asList("@IMPORT", "@APPLICATION", "@IN_RELATION_TO_OWN_USER"));
+    if (!withKeys) {
+      excludedPermissionNames.addAll(
+          Arrays.asList("@Key_Permission", "@FULL_MEMBER", "@BASIC_ACCESS"));
+    }
     permissions =
-        DBConnection.getEntityManager()
-            .createQuery(
-                "Select p from Permission p where not p.name in ('@IMPORT', '@APPLICATION', '@IN_RELATION_TO_OWN_USER'"
-                    + (withKeys ? "" : ", '@Key_Permission', '@FULL_MEMBER' ,'@BASIC_ACCESS'")
-                    + ")",
-                Permission.class)
-            .getResultList();
+        DBConnection.getConditioned(
+            Permission.class, Permission_.name.in(excludedPermissionNames).not());
   }
 
   @Override

--- a/app/src/main/java/kernbeisser/VersionIntegrationTools/UpdatingTools/PopulateSeqNo.java
+++ b/app/src/main/java/kernbeisser/VersionIntegrationTools/UpdatingTools/PopulateSeqNo.java
@@ -1,0 +1,20 @@
+package kernbeisser.VersionIntegrationTools.UpdatingTools;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import kernbeisser.DBConnection.DBConnection;
+import kernbeisser.VersionIntegrationTools.VersionUpdatingTool;
+import lombok.Cleanup;
+
+public class PopulateSeqNo implements VersionUpdatingTool {
+  @Override
+  public void runIntegration() {
+    @Cleanup EntityManager em = DBConnection.getEntityManager();
+    @Cleanup("commit")
+    EntityTransaction et = em.getTransaction();
+    et.begin();
+    em.createNativeQuery(
+            "UPDATE Transaction t1 Set seqNo = (SELECT count(1) FROM Transaction t2 WHERE t2.id < t1.id)")
+        .executeUpdate();
+  }
+}

--- a/app/src/main/java/kernbeisser/VersionIntegrationTools/UpdatingTools/PopulateSeqNo.java
+++ b/app/src/main/java/kernbeisser/VersionIntegrationTools/UpdatingTools/PopulateSeqNo.java
@@ -14,7 +14,8 @@ public class PopulateSeqNo implements VersionUpdatingTool {
     EntityTransaction et = em.getTransaction();
     et.begin();
     em.createNativeQuery(
-            "UPDATE Transaction t1 Set seqNo = (SELECT count(1) FROM Transaction t2 WHERE t2.id < t1.id)")
+            "UPDATE Transaction t1 SET seqNo = (SELECT count(*) FROM Transaction t2 WHERE t2.id < t1.id)")
         .executeUpdate();
+    em.createNativeQuery("UPDATE Purchase SET bonNo = id").executeUpdate();
   }
 }

--- a/app/src/main/java/kernbeisser/VersionIntegrationTools/Version.java
+++ b/app/src/main/java/kernbeisser/VersionIntegrationTools/Version.java
@@ -17,7 +17,8 @@ public enum Version {
   CATALOG_IMPORT(AddCatalogImportPermission::new),
   SALE_SESSION_CLOSE_POPUP(AddSaleSessionClosePermission::new),
   PREORDER_FROM_CATALOG(MigrateOpenPreOrders::new),
-  CONFIRMATION_PANEL(AddOnShoppingMaskCheckoutPermission::new);
+  CONFIRMATION_PANEL(AddOnShoppingMaskCheckoutPermission::new),
+  HIBERNATE_6_ID_SEQUENCE(PopulateSeqNo::new);
 
   private final Supplier<VersionUpdatingTool> versionUpdatingToolSupplier;
 

--- a/app/src/main/java/kernbeisser/Windows/AccountingReports/AccountingReportsView.java
+++ b/app/src/main/java/kernbeisser/Windows/AccountingReports/AccountingReportsView.java
@@ -209,7 +209,7 @@ public class AccountingReportsView extends JDialog implements IView<AccountingRe
   }
 
   private String BonNoAndDate(Purchase p) {
-    return p.getId() + " (" + Date.INSTANT_DATE.format(p.getCreateDate()) + ")";
+    return p.getBonNo() + " (" + Date.INSTANT_DATE.format(p.getCreateDate()) + ")";
   }
 
   private void createUIComponents() {

--- a/app/src/main/java/kernbeisser/Windows/LogIn/SimpleLogIn/SimpleLogInController.java
+++ b/app/src/main/java/kernbeisser/Windows/LogIn/SimpleLogIn/SimpleLogInController.java
@@ -52,13 +52,15 @@ public class SimpleLogInController extends Controller<SimpleLogInView, SimpleLog
   public void logIn() {
     SimpleLogInView view = getView();
     AtomicReference<Boolean> isAdminUser = new AtomicReference<>();
-    Access.runWithAccessManager(AccessManager.ACCESS_GRANTED, () -> {
-      isAdminUser.set(PermissionConstants.ADMIN.getPermission().getAllUsers().stream()
-              .anyMatch(u -> u.getUsername()
-                      .equals(view.getUsername())));
-      });
+    Access.runWithAccessManager(
+        AccessManager.ACCESS_GRANTED,
+        () -> {
+          isAdminUser.set(
+              PermissionConstants.ADMIN.getPermission().getAllUsers().stream()
+                  .anyMatch(u -> u.getUsername().equals(view.getUsername())));
+        });
     if (isAdminUser.get()) {
-        PermissionConstants.cleanAdminPermission(User.getByUsername("Admin"));
+      PermissionConstants.cleanAdminPermission(User.getByUsername("Admin"));
     }
     try {
       model.logIn(view.getUsername(), view.getPassword());

--- a/app/src/main/java/kernbeisser/Windows/Menu/MenuView.java
+++ b/app/src/main/java/kernbeisser/Windows/Menu/MenuView.java
@@ -43,7 +43,6 @@ import kernbeisser.Windows.MVC.IView;
 import kernbeisser.Windows.MVC.Linked;
 import kernbeisser.Windows.ManagePriceLists.ManagePriceListsController;
 import kernbeisser.Windows.PermissionAssignment.PermissionAssignmentController;
-import kernbeisser.Windows.PermissionAssignment.PermissionAssignmentModel;
 import kernbeisser.Windows.PermissionGranterAssignment.PermissionGranterAssignmentController;
 import kernbeisser.Windows.PermissionManagement.PermissionController;
 import kernbeisser.Windows.PreOrder.PreOrderController;
@@ -264,7 +263,7 @@ public class MenuView implements IView<MenuController> {
     permissionAssignment =
         new ControllerButton(
             PermissionAssignmentController::new, PermissionAssignmentController.class);
-    //permissionAssignment.setEnabled(PermissionAssignmentModel.isAccessible());
+    // permissionAssignment.setEnabled(PermissionAssignmentModel.isAccessible());
 
     permissionGranterAssignment =
         new ControllerButton(

--- a/app/src/main/java/kernbeisser/Windows/Pay/PayController.java
+++ b/app/src/main/java/kernbeisser/Windows/Pay/PayController.java
@@ -38,9 +38,9 @@ public class PayController extends Controller<PayView, PayModel> {
     PayView view = getView();
     // FIXME why pass shoppingCart to model if it was initialized with it?
     try {
-      long purchaseId = model.pay();
+      long bonNo = model.pay();
       if (printReceipt) {
-        PayModel.print(purchaseId);
+        PayModel.print(bonNo);
       }
       view.confirmLogging(
           model.getSaleSession().getCustomer().getFullName(), model.shoppingCartSum());

--- a/app/src/main/java/kernbeisser/Windows/PermissionAssignment/PermissionAssignmentController.java
+++ b/app/src/main/java/kernbeisser/Windows/PermissionAssignment/PermissionAssignmentController.java
@@ -88,9 +88,7 @@ public class PermissionAssignmentController
     Optional<Collection<User>> before = model.getRecent().map(model::assignedUsers);
     if (!before.isPresent() || before.get().equals(user.getModel().getLoaded())) return;
     model.setPermission(
-        model.getRecent().get(),
-        user.getModel().getLoaded(),
-        () -> getView().confirmChanges());
+        model.getRecent().get(), user.getModel().getLoaded(), () -> getView().confirmChanges());
   }
 
   @Override

--- a/app/src/main/java/kernbeisser/Windows/PermissionAssignment/PermissionAssignmentModel.java
+++ b/app/src/main/java/kernbeisser/Windows/PermissionAssignment/PermissionAssignmentModel.java
@@ -65,9 +65,7 @@ public class PermissionAssignmentModel implements IModel<PermissionAssignmentCon
   }
 
   public void setPermission(
-      Permission permission,
-      Collection<User> loaded,
-      Supplier<Boolean> confirm) {
+      Permission permission, Collection<User> loaded, Supplier<Boolean> confirm) {
     @Cleanup EntityManager em = DBConnection.getEntityManager();
     @Cleanup(value = "commit")
     EntityTransaction et = em.getTransaction();
@@ -78,9 +76,7 @@ public class PermissionAssignmentModel implements IModel<PermissionAssignmentCon
     hadBefore.removeAll(notToRemove);
     Collection<User> willGet = loaded.stream().map(e -> em.find(User.class, e.getId())).toList();
     if (!(hadBefore.isEmpty() && willGet.isEmpty()) && confirm.get()) {
-      hadBefore.stream()
-          .peek(e -> e.getPermissions().remove(permission))
-          .forEach(em::persist);
+      hadBefore.stream().peek(e -> e.getPermissions().remove(permission)).forEach(em::persist);
       willGet.stream().peek(e -> e.getPermissions().add(permission)).forEach(em::persist);
     }
     em.flush();

--- a/app/src/main/java/kernbeisser/Windows/Purchase/PurchaseController.java
+++ b/app/src/main/java/kernbeisser/Windows/Purchase/PurchaseController.java
@@ -37,7 +37,7 @@ public class PurchaseController extends Controller<PurchaseView, PurchaseModel> 
   }
 
   public void printBon() {
-    PayModel.printAt(model.getLoaded().getId());
+    PayModel.printAt(model.getLoaded().getBonNo());
   }
 
   public void fillShoppingCart() {

--- a/app/src/main/java/kernbeisser/Windows/TabbedPane/DefaultTab.java
+++ b/app/src/main/java/kernbeisser/Windows/TabbedPane/DefaultTab.java
@@ -23,6 +23,8 @@ public class DefaultTab {
   private JButton close;
 
   DefaultTab(Icon icon, String title, Runnable closeOperation, Runnable click) {
+    // @spotless:off
+
     $$$setupUI$$$();
     this.icon.setIcon(icon);
     this.tabTitle.setText(title);
@@ -130,4 +132,5 @@ public class DefaultTab {
         return main;
     }
 
+  // @spotless:on
 }

--- a/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoController.java
+++ b/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoController.java
@@ -50,7 +50,7 @@ public class UserInfoController extends Controller<UserInfoView, UserInfoModel> 
   }
 
   public Double getTransactionSum(Transaction t) {
-    return model.getTransactionSums().get(t.getId());
+    return model.getTransactionSums().get(t.getSeqNo());
   }
 
   public void openPurchase() {

--- a/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoModel.java
+++ b/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoModel.java
@@ -37,7 +37,7 @@ public class UserInfoModel implements IModel<UserInfoController> {
     var resultList =
         QueryBuilder.select(
                 Transaction.class,
-                Transaction_.id,
+                Transaction_.seqNo,
                 Transaction_.value,
                 Transaction_.toUserGroup.eq(userGroup))
             .where(
@@ -48,7 +48,7 @@ public class UserInfoModel implements IModel<UserInfoController> {
             .getResultList();
     Map<Long, Double> idValueAfterMap = new HashMap<>(resultList.size());
     for (Tuple tuple : resultList) {
-      long id = tuple.get(0, Long.class);
+      long seqNo = tuple.get(0, Long.class);
       double value = tuple.get(1, Double.class);
       boolean incoming = tuple.get(2, Boolean.class);
       if (incoming) {
@@ -56,7 +56,7 @@ public class UserInfoModel implements IModel<UserInfoController> {
       } else {
         sum -= value;
       }
-      idValueAfterMap.put(id, sum);
+      idValueAfterMap.put(seqNo, sum);
     }
     return idValueAfterMap;
   }

--- a/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoView.java
+++ b/app/src/main/java/kernbeisser/Windows/UserInfo/UserInfoView.java
@@ -161,12 +161,14 @@ public class UserInfoView implements IView<UserInfoController> {
 
     shoppingHistory =
         new ObjectTable<Purchase>(
+                Columns.create("Bon", Purchase::getBonNo).withSorter(Column.NUMBER_SORTER),
                 Columns.<Purchase>create(
                         "Datum", e -> Date.INSTANT_DATE_TIME.format(e.getCreateDate()))
                     .withSorter(Column.DATE_SORTER(Date.INSTANT_DATE_TIME)),
                 Columns.create("Verkäufer", e -> e.getSession().getSeller()),
                 Columns.create("Käufer", e -> e.getSession().getCustomer()),
-                Columns.create("Summe", e -> format("%.2f€", e.getSum()), SwingConstants.RIGHT))
+                Columns.<Purchase>create("Summe", e -> format("%.2f€", e.getSum()))
+                    .withSorter(Column.NUMBER_SORTER))
             .allowCaching();
 
     phoneNumber1 = new AccessCheckingLabel<>(User::getPhoneNumber1);

--- a/app/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
+++ b/app/src/test/java/kernbeisser/Reports/InvoiceReportTest.java
@@ -46,6 +46,7 @@ class InvoiceReportTest {
     when(session.getSeller()).thenReturn(user);
     when(purchase.getSession()).thenReturn(session);
     when(purchase.getCreateDate()).thenReturn(now);
+    when(purchase.getBonNo()).thenReturn(42L);
     when(purchase.getId()).thenReturn(42L);
     return purchase;
   }

--- a/reports/Bonrolle.jrxml
+++ b/reports/Bonrolle.jrxml
@@ -26,10 +26,10 @@
 	<field name="itemMultiplier" class="java.lang.Integer"/>
 	<field name="itemRetailPrice" class="java.lang.Double"/>
 	<field name="purchase.createDate" class="java.time.Instant"/>
-	<field name="purchase.id" class="java.lang.Long"/>
+	<field name="purchase.bonNo" class="java.lang.Long"/>
 	<field name="displayAmount" class="java.lang.String"/>
 	<group name="Purchase">
-		<groupExpression><![CDATA[$F{purchase.id}]]></groupExpression>
+		<groupExpression><![CDATA[$F{purchase.bonNo}]]></groupExpression>
 		<groupHeader>
 			<band height="19">
 				<textField>
@@ -39,7 +39,7 @@
 					<textElement textAlignment="Left">
 						<font fontName="DejaVu Sans Condensed" isItalic="true"/>
 					</textElement>
-					<textFieldExpression><![CDATA["Bon Nummer: " + $F{purchase.id}]]></textFieldExpression>
+					<textFieldExpression><![CDATA["Bon Nummer: " + $F{purchase.bonNo}]]></textFieldExpression>
 				</textField>
 				<textField pattern="dd.MM.yyyy HH:mm">
 					<reportElement x="230" y="0" width="150" height="14" uuid="0e295a26-392b-4848-bc0c-2ba61724b912">

--- a/reports/BuchhaltungBonUebersicht.jrxml
+++ b/reports/BuchhaltungBonUebersicht.jrxml
@@ -26,7 +26,7 @@
 		<![CDATA[]]>
 	</queryString>
 	<field name="createDate" class="java.time.Instant"/>
-	<field name="id" class="java.lang.Long"/>
+	<field name="bonNo" class="java.lang.Long"/>
 	<field name="customerIdentification" class="java.lang.String"/>
 	<field name="sum" class="java.lang.Double"/>
 	<field name="session.sessionTypeName" class="java.lang.String"/>
@@ -154,7 +154,7 @@
 				<textElement textAlignment="Right">
 					<font fontName="DejaVu Sans Condensed"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{id}]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{bonNo}]]></textFieldExpression>
 			</textField>
 			<textField textAdjust="ScaleFont">
 				<reportElement x="44" y="-9" width="326" height="14" uuid="b5b27eb9-28ac-4c0b-8de8-d2eff2aaa9a8">


### PR DESCRIPTION
In Hibernate 6 werden Ids nicht mehr über alle Entities inkrementiert, sondern pro Klasse. Außerdem werden Ids, die vorher noch nie vergeben wurden, u.U. verwendet, auch wenn es bereits höhere Ids gibt. Das hat zur Folge, dass Operationen, die davon ausgehen, dass neuere Datensätze grundsätzlich auch höhere Ids haben, fehleranfällig werden. Daher muss für diese Operationen eine neue Eigenschaft eingeführt werden, die strikt squenziell in der Zeit ist.
Das betrifft nach bisherigen Analysen nur die Transaction.
Die Purchase Id wird als Bonnummer verwendet, verwendet aber ein Inkrementierungsmodell, das von der Hibernate-Anpassung nicht betroffen ist. Dennoch sollte die Bonnummer genauso auf eine Logik umgestellt werden, die ausschließlich durch die Applikation verwaltet wird, um künftige Probleme zu vermeiden.